### PR TITLE
feat: install service as user service

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,13 +37,13 @@
 - 下载并解压[https://github.com/jeessy2/ddns-go/releases](https://github.com/jeessy2/ddns-go/releases)
 - 双击运行, 如没有找到配置, 程序自动打开[http://127.0.0.1:9876](http://127.0.0.1:9876)
 - [可选] 安装服务
-  - Mac/Linux: `sudo ./ddns-go -s install` 
-  - Win(以管理员打开cmd): `.\ddns-go.exe -s install`
+  - Mac/Linux: `./ddns-go -s install` 
+  - Win(打开cmd): `.\ddns-go.exe -s install`
   - 安装服务也支持 `-l`监听地址 `-f`同步间隔时间(秒)
 - [可选] 服务卸载
-  - Mac/Linux: `sudo ./ddns-go -s uninstall` 
-  - Win(以管理员打开cmd): `.\ddns-go.exe -s uninstall`
-- [可选] 支持启动带参数 `-l`监听地址 `-f`同步间隔时间(秒)。如：`sudo ./ddns-go -l 127.0.0.1:9876 -f 600`
+  - Mac/Linux: `./ddns-go -s uninstall` 
+  - Win(打开cmd): `.\ddns-go.exe -s uninstall`
+- [可选] 支持启动带参数 `-l`监听地址 `-f`同步间隔时间(秒)。如：`./ddns-go -l 127.0.0.1:9876 -f 600`
 
 ## Docker中使用
 

--- a/main.go
+++ b/main.go
@@ -59,7 +59,7 @@ func main() {
 				case "windows-service":
 					log.Println("可使用 .\\ddns-go.exe -s install 安装服务运行")
 				default:
-					log.Println("可使用 sudo ./ddns-go -s install 安装服务运行")
+					log.Println("可使用 ./ddns-go -s install 安装服务运行")
 				}
 				run(100 * time.Millisecond)
 			}
@@ -166,9 +166,9 @@ func installService() {
 		log.Printf("安装 ddns-go 服务失败, ERR: %s\n", err)
 		switch s.Platform() {
 		case "windows-service":
-			log.Println("请以管理员身份运行cmd并确保使用如下命令: .\\ddns-go.exe -s install")
+			log.Println("请确保使用如下命令: .\\ddns-go.exe -s install")
 		default:
-			log.Println("请确保使用如下命令: sudo ./ddns-go -s install")
+			log.Println("请确保使用如下命令: ./ddns-go -s install")
 		}
 	}
 


### PR DESCRIPTION
Tested in Mac, Linux and Windows.

With this pr, user no longer need to run `ddns-go` as root or administor.

Releated #67 