### PR TITLE
add `-trimpath` flags to goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,6 +9,8 @@ before:
 builds:
   - env:
       - CGO_ENABLED=0
+    flags:
+      - -trimpath
     goos:
       - linux
       - windows


### PR DESCRIPTION
Using flag `-trimpath` for `go build` could use the file name which begins with `path@version` (for go modules) instead of `absolute file system path`. It can help with reducing the build file size (and not associated with a GitHub action environment).

Reference: [pkg.go.dev/cmd/go](https://pkg.go.dev/cmd/go#hdr-Compile_packages_and_dependencies)

## comparation

### without `-trimpath`

It'll be 7,845,888 bytes.

![image](https://user-images.githubusercontent.com/15844309/159270724-e1d3098b-bb33-40e7-9bdd-2ea87c8bccfe.png)

### with `-trimpath`

It'll be 7,823,872 bytes.

![image](https://user-images.githubusercontent.com/15844309/159270539-8a9118fe-e007-42b3-9755-5d138a939b64.png)
