### PR TITLE
:lock: 对配置中的关键字段进行混淆

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -95,6 +95,20 @@ func GetConfigCache() (conf Config, err error) {
 		cache.Err = err
 		return *cache.ConfigSingle, err
 	}
+
+	// Try to reveal some fields
+	// Currently, DNS.Id & DNS.Secret can use obscured string
+	cache.ConfigSingle.DNS.ID, cache.Err = util.Reveal(cache.ConfigSingle.DNS.ID)
+	if cache.Err != nil {
+		log.Println("Obscured DNS ID given cannot be revealed")
+		return *cache.ConfigSingle, err
+	}
+	cache.ConfigSingle.DNS.Secret, cache.Err = util.Reveal(cache.ConfigSingle.DNS.Secret)
+	if cache.Err != nil {
+		log.Println("Obscured DNS secret given cannot be revealed")
+		return *cache.ConfigSingle, err
+	}
+
 	// remove err
 	cache.Err = nil
 	return *cache.ConfigSingle, err

--- a/config/config.go
+++ b/config/config.go
@@ -52,6 +52,7 @@ type DNSConfig struct {
 	Name   string
 	ID     string
 	Secret string
+	Proxy  string
 }
 
 // ConfigCache ConfigCache

--- a/dns/cloudflare.go
+++ b/dns/cloudflare.go
@@ -202,7 +202,7 @@ func (cf *Cloudflare) request(method string, url string, data interface{}, resul
 	req.Header.Set("Authorization", "Bearer "+cf.DNSConfig.Secret)
 	req.Header.Set("Content-Type", "application/json")
 
-	client := util.CreateHTTPClient()
+	client := util.CreateHTTPClientWithProxy(cf.DNSConfig.Proxy)
 	resp, err := client.Do(req)
 	err = util.GetHTTPResponse(resp, url, err, result)
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,14 @@ go 1.17
 require (
 	github.com/kardianos/service v1.2.1
 	github.com/mitchellh/go-homedir v1.1.0
+	github.com/pkg/errors v0.9.1
+	github.com/stretchr/testify v1.7.1
 	gopkg.in/yaml.v2 v2.4.0
 )
 
-require golang.org/x/sys v0.0.0-20220403020550-483a9cbc67c0 // indirect
+require (
+	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	golang.org/x/sys v0.0.0-20220403020550-483a9cbc67c0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,16 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/kardianos/service v1.2.1 h1:AYndMsehS+ywIS6RB9KOlcXzteWUzxgMgBymJD7+BYk=
 github.com/kardianos/service v1.2.1/go.mod h1:CIMRFEJVL+0DS1a3Nx06NaMn4Dz63Ng6O7dl0qH0zVM=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 golang.org/x/sys v0.0.0-20201015000850-e3ed0017c211/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20220403020550-483a9cbc67c0 h1:PgUUmg0gNMIPY2WafhL/oLyQGw+kdTNPlVWOjltpp3w=
 golang.org/x/sys v0.0.0-20220403020550-483a9cbc67c0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -9,3 +18,5 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/main.go
+++ b/main.go
@@ -32,6 +32,9 @@ var serviceType = flag.String("s", "", "服务管理, 支持install, uninstall")
 // 配置文件路径
 var configFilePath = flag.String("c", util.GetConfigFilePathDefault(), "自定义配置文件路径")
 
+// 生成混淆字符串
+var obscure = flag.String("o", "", "生成混淆字符串，目前仅支持为 DNS.ID 与 DNS.Secret 字段设置混淆后的字符串")
+
 //go:embed static
 var staticEmbededFiles embed.FS
 
@@ -43,6 +46,10 @@ var version = "DEV"
 
 func main() {
 	flag.Parse()
+	if *obscure != "" {
+		fmt.Println(util.MustObscure(*obscure))
+		return
+	}
 	if _, err := net.ResolveTCPAddr("tcp", *listen); err != nil {
 		log.Fatalf("解析监听地址异常，%s", err)
 	}

--- a/main.go
+++ b/main.go
@@ -35,6 +35,9 @@ var configFilePath = flag.String("c", util.GetConfigFilePathDefault(), "自定�
 // 生成混淆字符串
 var obscure = flag.String("o", "", "生成混淆字符串，目前仅支持为 DNS.ID 与 DNS.Secret 字段设置混淆后的字符串")
 
+// 还原已混淆的字符串
+var reveal = flag.String("r", "", "将混淆字符串还原")
+
 //go:embed static
 var staticEmbededFiles embed.FS
 
@@ -48,6 +51,10 @@ func main() {
 	flag.Parse()
 	if *obscure != "" {
 		fmt.Println(util.MustObscure(*obscure))
+		return
+	}
+	if *reveal != "" {
+		fmt.Println(util.MustReveal(*reveal))
 		return
 	}
 	if _, err := net.ResolveTCPAddr("tcp", *listen); err != nil {

--- a/util/http_util.go
+++ b/util/http_util.go
@@ -78,8 +78,12 @@ func CreateHTTPClient() *http.Client {
 
 func CreateHTTPClientWithProxy(proxyUrl string) *http.Client {
 
-	// Proxy URL check: format check
 	client := CreateHTTPClient()
+	if proxyUrl == "" {
+		return client
+	}
+
+	// Proxy URL format check
 	_, err := url.ParseRequestURI(proxyUrl)
 	if err != nil {
 		log.Println("Proxy parse error, disable the proxy")

--- a/util/obscure.go
+++ b/util/obscure.go
@@ -1,0 +1,106 @@
+// From Rclone: https://github.com/rclone/rclone
+// License: MIT
+package util
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"log"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+const (
+	obscuredPrefix = "*bcb25d17" // Use a prefix to identify if a string is obscured
+)
+
+// crypt internals
+var (
+	cryptKey = []byte{
+		0x9c, 0x93, 0x5b, 0x48, 0x73, 0x0a, 0x55, 0x4d,
+		0x6b, 0xfd, 0x7c, 0x63, 0xc8, 0x86, 0xa9, 0x2b,
+		0xd3, 0x90, 0x19, 0x8e, 0xb8, 0x12, 0x8a, 0xfb,
+		0xf4, 0xde, 0x16, 0x2b, 0x8b, 0x95, 0xf6, 0x38,
+	}
+	cryptBlock cipher.Block
+	cryptRand  = rand.Reader
+)
+
+// crypt transforms in to out using iv under AES-CTR.
+//
+// in and out may be the same buffer.
+//
+// Note encryption and decryption are the same operation
+func crypt(out, in, iv []byte) error {
+	if cryptBlock == nil {
+		var err error
+		cryptBlock, err = aes.NewCipher(cryptKey)
+		if err != nil {
+			return err
+		}
+	}
+	stream := cipher.NewCTR(cryptBlock, iv)
+	stream.XORKeyStream(out, in)
+	return nil
+}
+
+// Obscure a value
+//
+// This is done by encrypting with AES-CTR
+func Obscure(x string) (string, error) {
+	plaintext := []byte(x)
+	ciphertext := make([]byte, aes.BlockSize+len(plaintext))
+	iv := ciphertext[:aes.BlockSize]
+	if _, err := io.ReadFull(cryptRand, iv); err != nil {
+		return "", errors.Wrap(err, "failed to read iv")
+	}
+	if err := crypt(ciphertext[aes.BlockSize:], plaintext, iv); err != nil {
+		return "", errors.Wrap(err, "encrypt failed")
+	}
+	return fmt.Sprint(obscuredPrefix, base64.RawURLEncoding.EncodeToString(ciphertext)), nil
+}
+
+// MustObscure obscures a value, exiting with a fatal error if it failed
+func MustObscure(x string) string {
+	out, err := Obscure(x)
+	if err != nil {
+		log.Fatalf("Obscure failed: %v", err)
+	}
+	return out
+}
+
+// Reveal an obscured value
+func Reveal(x string) (string, error) {
+	if index := strings.Index(x, obscuredPrefix); index < 0 {
+		// String x does not contain the obscured prefix, skip revealing
+		return x, nil
+	}
+	x = strings.Replace(x, obscuredPrefix, "", 1)
+	ciphertext, err := base64.RawURLEncoding.DecodeString(x)
+	if err != nil {
+		return "", errors.Wrap(err, "base64 decode failed when revealing password - is it obscured?")
+	}
+	if len(ciphertext) < aes.BlockSize {
+		return "", errors.New("input too short when revealing password - is it obscured?")
+	}
+	buf := ciphertext[aes.BlockSize:]
+	iv := ciphertext[:aes.BlockSize]
+	if err := crypt(buf, buf, iv); err != nil {
+		return "", errors.Wrap(err, "decrypt failed when revealing password - is it obscured?")
+	}
+	return string(buf), nil
+}
+
+// MustReveal reveals an obscured value, exiting with a fatal error if it failed
+func MustReveal(x string) string {
+	out, err := Reveal(x)
+	if err != nil {
+		log.Fatalf("Reveal failed: %v", err)
+	}
+	return out
+}

--- a/util/obscure_test.go
+++ b/util/obscure_test.go
@@ -1,0 +1,77 @@
+package util
+
+import (
+	"bytes"
+	"crypto/rand"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestObscure(t *testing.T) {
+	for _, test := range []struct {
+		in   string
+		want string
+		iv   string
+	}{
+		{"", "*bcb25d17YWFhYWFhYWFhYWFhYWFhYQ", "aaaaaaaaaaaaaaaa"},
+		{"potato", "*bcb25d17YWFhYWFhYWFhYWFhYWFhYXMaGgIlEQ", "aaaaaaaaaaaaaaaa"},
+		{"potato", "*bcb25d17YmJiYmJiYmJiYmJiYmJiYp3gcEWbAw", "bbbbbbbbbbbbbbbb"},
+	} {
+		cryptRand = bytes.NewBufferString(test.iv)
+		got, err := Obscure(test.in)
+		cryptRand = rand.Reader
+		assert.NoError(t, err)
+		assert.Equal(t, test.want, got)
+		recoveredIn, err := Reveal(got)
+		assert.NoError(t, err)
+		assert.Equal(t, test.in, recoveredIn, "not bidirectional")
+		// Now the Must variants
+		cryptRand = bytes.NewBufferString(test.iv)
+		got = MustObscure(test.in)
+		cryptRand = rand.Reader
+		assert.Equal(t, test.want, got)
+		recoveredIn = MustReveal(got)
+		assert.Equal(t, test.in, recoveredIn, "not bidirectional")
+
+	}
+}
+
+func TestReveal(t *testing.T) {
+	for _, test := range []struct {
+		in   string
+		want string
+		iv   string
+	}{
+		{"*bcb25d17YWFhYWFhYWFhYWFhYWFhYQ", "", "aaaaaaaaaaaaaaaa"},
+		{"*bcb25d17YWFhYWFhYWFhYWFhYWFhYXMaGgIlEQ", "potato", "aaaaaaaaaaaaaaaa"},
+		{"*bcb25d17YmJiYmJiYmJiYmJiYmJiYp3gcEWbAw", "potato", "bbbbbbbbbbbbbbbb"},
+		{"YmJiYmJiYmJiYmJiYmJiYp3gcEWbAw", "YmJiYmJiYmJiYmJiYmJiYp3gcEWbAw", "bbbbbbbbbbbbbbbb"},
+	} {
+		cryptRand = bytes.NewBufferString(test.iv)
+		got, err := Reveal(test.in)
+		assert.NoError(t, err)
+		assert.Equal(t, test.want, got)
+		// Now the Must variants
+		cryptRand = bytes.NewBufferString(test.iv)
+		got = MustReveal(test.in)
+		assert.Equal(t, test.want, got)
+
+	}
+}
+
+// Test some error cases
+func TestRevealErrors(t *testing.T) {
+	for _, test := range []struct {
+		in      string
+		wantErr string
+	}{
+		{"*bcb25d17YmJiYmJiYmJiYmJiYmJiYp*gcEWbAw", "base64 decode failed when revealing password - is it obscured?: illegal base64 data at input byte 22"},
+		{"*bcb25d17aGVsbG8", "input too short when revealing password - is it obscured?"},
+		{"*bcb25d17", "input too short when revealing password - is it obscured?"},
+	} {
+		gotString, gotErr := Reveal(test.in)
+		assert.Equal(t, "", gotString)
+		assert.Equal(t, test.wantErr, gotErr.Error())
+	}
+}

--- a/web/save.go
+++ b/web/save.go
@@ -18,11 +18,22 @@ func Save(writer http.ResponseWriter, request *http.Request) {
 
 	idHide, secretHide := getHideIDSecret(&conf)
 
+	// Obscure by default if using Web GUI to manage config file
+	var err error = nil
 	if idNew != idHide {
-		conf.DNS.ID = idNew
+		conf.DNS.ID, err = util.Obscure(idNew)
+		if err != nil {
+			writer.Write([]byte(err.Error()))
+			return
+		}
 	}
+
 	if secretNew != secretHide {
-		conf.DNS.Secret = secretNew
+		conf.DNS.Secret, err = util.Obscure(secretNew)
+		if err != nil {
+			writer.Write([]byte(err.Error()))
+			return
+		}
 	}
 
 	// 覆盖以前的配置
@@ -51,7 +62,7 @@ func Save(writer http.ResponseWriter, request *http.Request) {
 	conf.TTL = request.FormValue("TTL")
 
 	// 保存到用户目录
-	err := conf.SaveConfig()
+	err = conf.SaveConfig()
 
 	// 只运行一次
 	util.Ipv4Cache.ForceCompare = true


### PR DESCRIPTION
## 密钥字段混淆 #187

### 支持的字段
* DNS.ID  
* DNS.Secret  

### 使用方法

通过```-o```参数对明文进行混淆：
```./ddns-go -o [string]```
程序将输出以```*bcb25d17```为前缀的字符串，将其填入配置文件相应位置即可。

使用```-r```参数对已混淆的字符串进行还原：
```./ddns-go -r [string]```
若输入的字符串不包含```*bcb25d17```的前缀，输出的字符串将不会有任何改变。

使用 Web GUI 进行配置文件管理：
写入配置文件的相关字符串将默认进行混淆处理，无需额外干预。

> 由于混淆使用的 [base64 URL ](https://en.wikipedia.org/wiki/Base64#Variants_summary_table) 并未使用 * 字符，因此以```*bcb25d17```作为辨识混淆字符串的前缀；
> 该字符串同时具有一定的随机性，可以同 base64 URL 进行区分的同时，不易同各 DDNS 厂商所使用的 ID 或 Token 出现冲突。

### 注意事项
1. 本混淆方案仍然是一种 ***不安全*** 的解决方案，仅可避免该配置文件被他人 ***无意识地看到***，而无法抵御 ***有意识的窃密***；  
2. 如无意使用参数混淆，只需将明文字符串填入配置文件中即可，程序检测到字符串不包含```*bcb25d17```时将不做还原处理，不影响旧版本配置文件的使用。

## 代理设置 #169

### 新增配置字段
DNS.Proxy

### 使用方法
在配置文件中设置 ```proxy```：
```yaml
...
dns:
  name: cloudflare
  id: "***"
  secret: '****'
  proxy: 'socks5://localhost:1080' # 同时支持 sock5 和 http 代理，但不支持认证
...
```

### 注意事项
1. 不支持 Web GUI 修改，需要手动修改配置文件；
2. 仅对 CloudFlare DDNS 生效，后续由作者决定是否对其它 DDNS 服务商生效；
3. 自动检测代理 URL 格式正确性和代理可用性（通过尝试连接 [gstatic](http://www.gstatic.com/generate_204) 进行检测），任一检测未通过则不使用代理。