### PR TITLE
feat: add custom user primary domain support

### DIFF
--- a/config/domains.go
+++ b/config/domains.go
@@ -96,31 +96,48 @@ func checkParseDomains(domainArr []string) (domains []*Domain) {
 	for _, domainStr := range domainArr {
 		domainStr = strings.TrimSpace(domainStr)
 		if domainStr != "" {
-			domain := &Domain{}
-			sp := strings.Split(domainStr, ".")
-			length := len(sp)
-			if length <= 1 {
-				log.Println(domainStr, "域名不正确")
-				continue
-			}
-			// 处理域名
-			domain.DomainName = sp[length-2] + "." + sp[length-1]
-			// 如包含在org.cn等顶级域名下，后三个才为用户主域名
-			for _, staticMainDomain := range staticMainDomains {
-				if staticMainDomain == domain.DomainName {
-					domain.DomainName = sp[length-3] + "." + domain.DomainName
-					break
+			dp := strings.Split(domainStr, ":")
+			dplen := len(dp)
+			if dplen == 1 { // 自动识别域名
+				domain := &Domain{}
+				sp := strings.Split(domainStr, ".")
+				length := len(sp)
+				if length <= 1 {
+					log.Println(domainStr, "域名不正确")
+					continue
 				}
-			}
+				// 处理域名
+				domain.DomainName = sp[length-2] + "." + sp[length-1]
+				// 如包含在org.cn等顶级域名下，后三个才为用户主域名
+				for _, staticMainDomain := range staticMainDomains {
+					if staticMainDomain == domain.DomainName {
+						domain.DomainName = sp[length-3] + "." + domain.DomainName
+						break
+					}
+				}
 
-			domainLen := len(domainStr) - len(domain.DomainName)
-			if domainLen > 0 {
-				domain.SubDomain = domainStr[:domainLen-1]
+				domainLen := len(domainStr) - len(domain.DomainName)
+				if domainLen > 0 {
+					domain.SubDomain = domainStr[:domainLen-1]
+				} else {
+					domain.SubDomain = domainStr[:domainLen]
+				}
+
+				domains = append(domains, domain)
+			} else if dplen == 2 { // 主机记录:域名 格式
+				domain := &Domain{}
+				sp := strings.Split(dp[1], ".")
+				length := len(sp)
+				if length <= 1 {
+					log.Println(domainStr, "域名不正确")
+					continue
+				}
+				domain.DomainName = dp[1]
+				domain.SubDomain = dp[0]
+				domains = append(domains, domain)
 			} else {
-				domain.SubDomain = domainStr[:domainLen]
+				log.Println(domainStr, "域名不正确")
 			}
-
-			domains = append(domains, domain)
 		}
 	}
 	return

--- a/dns/alidns.go
+++ b/dns/alidns.go
@@ -70,6 +70,7 @@ func (ali *Alidns) addUpdateDomainRecords(recordType string) {
 		// 获取当前域名信息
 		params := url.Values{}
 		params.Set("Action", "DescribeSubDomainRecords")
+		params.Set("DomainName", domain.DomainName)
 		params.Set("SubDomain", domain.GetFullDomain())
 		params.Set("Type", recordType)
 		err := ali.request(params, &record)

--- a/web/writing.html
+++ b/web/writing.html
@@ -110,7 +110,7 @@
               </div>
 
               <div class="form-group row">
-                <label for="ipv4_url" class="col-sm-2 col-form-label">获取IP方式</label>
+                <label for="ipv4_url" class="col-sm-2 col-form-label">获取 IP 方式</label>
                 <div class="col-sm-10">
                   <div class="form-check form-check-inline">
                     <input class="form-check-input" type="radio" name="Ipv4GetType" id="urlRadioIpv4" value="url" {{if ne .Ipv4.GetType "netInterface"}}checked{{end}} onclick="urlClick('ipv4')">
@@ -134,7 +134,7 @@
 {{$v}}
 {{- end -}}
                   </textarea>
-                  <small id="ipv4_domains_help" class="form-text text-muted">一行一个域名</small>
+                  <small id="ipv4_domains_help" class="form-text text-muted">一行一个域名, 可使用冒号手动分隔主机记录, 如： ddns.example.com, ddns:example.com</small>
                 </div>
               </div>
 
@@ -153,7 +153,7 @@
               </div>
 
               <div class="form-group row">
-                <label for="ipv6_url" class="col-sm-2 col-form-label">获取IP方式</label>
+                <label for="ipv6_url" class="col-sm-2 col-form-label">获取 IP 方式</label>
                 <div class="col-sm-10">
                   <div class="form-check form-check-inline">
                     <input class="form-check-input" type="radio" name="Ipv6GetType" id="urlRadioIpv6" value="url" {{if ne .Ipv6.GetType "netInterface"}}checked{{end}} onclick="urlClick('ipv6')">
@@ -185,7 +185,7 @@
 {{$v}}
 {{- end -}}
                   </textarea>
-                  <small id="ipv6_domains_help" class="form-text text-muted">一行一个域名</small>
+                  <small id="ipv6_domains_help" class="form-text text-muted">一行一个域名, 可使用冒号手动分隔主机记录, 如： ddns.example.com, ddns:example.com</small>
                 </div>
               </div>
 
@@ -234,7 +234,7 @@
                     <option value="1800" {{if eq .TTL "1800"}}selected{{end}}>30分钟</option>
                     <option value="3600" {{if eq .TTL "3600"}}selected{{end}}>1小时</option>
                   </select>
-                  <small id="ttl_help" class="form-text text-muted">如账号支持更小的TTL, 可修改. IP有变化时才会更新TTL</small>
+                  <small id="ttl_help" class="form-text text-muted">如账号支持更小的 TTL , 可修改。 IP 有变化时才会更新 TTL</small>
                 </div>
               </div>
 
@@ -250,8 +250,8 @@
                 <div class="col-sm-10">
                   <input class="form-control" name="WebhookURL" id="WebhookURL" value="{{.WebhookURL}}" aria-describedby="WebhookURL_help">
                   <small id="WebhookURL_help" class="form-text text-muted">
-                    <a target="blank" href="https://github.com/jeessy2/ddns-go#webhook">点击参考官方Webhook说明</a><br/>
-                    支持的变量#{ipv4Addr}, #{ipv4Result}, #{ipv4Domains}, #{ipv6Addr}, #{ipv6Result}, #{ipv6Domains}
+                    <a target="blank" href="https://github.com/jeessy2/ddns-go#webhook">点击参考官方 Webhook 说明</a><br/>
+                    支持的变量 #{ipv4Addr}, #{ipv4Result}, #{ipv4Domains}, #{ipv6Addr}, #{ipv6Result}, #{ipv6Domains}
                   </small>
                 </div>
               </div>
@@ -263,7 +263,7 @@
 {{- .WebhookRequestBody -}}
                   </textarea>
                   <small id="WebhookRequestBody_help" class="form-text text-muted">
-                    RequestBody为空GET请求，不为空POST请求。支持的变量同上
+                    RequestBody 为空 GET 请求，不为空 POST 请求。支持的变量同上
                   </small>
                 </div>
               </div>
@@ -347,7 +347,7 @@
       document.getElementById("DnsID").disabled= true
       document.getElementById("DnsID").value= ""
       document.getElementById("dnsSecretLabel").innerHTML = "Token"
-      document.getElementById("dns_help").innerHTML = "<a target='_blank' href='https://dash.cloudflare.com/profile/api-tokens'>创建令牌->编辑区域 DNS(使用模板)</a>"
+      document.getElementById("dns_help").innerHTML = "<a target='_blank' href='https://dash.cloudflare.com/profile/api-tokens'>创建令牌->编辑区域 DNS (使用模板)</a>"
     }
 
     function huaweicloudCheckedFun() {
@@ -367,7 +367,7 @@
 
       document.getElementById("dnsIdLabel").innerHTML = "URL"
       document.getElementById("dnsSecretLabel").innerHTML = "RequestBody"
-      document.getElementById("dns_help").innerHTML = "<a target='_blank' href='https://github.com/jeessy2/ddns-go#callback'>自定义回调</a> 支持的变量#{ip}, #{domain}, #{recordType}, #{ttl}"
+      document.getElementById("dns_help").innerHTML = "<a target='_blank' href='https://github.com/jeessy2/ddns-go#callback'>自定义回调</a> 支持的变量 #{ip}, #{domain}, #{recordType}, #{ttl}"
     }
 
     function baiducloudCheckedFun() {
@@ -376,7 +376,7 @@
         document.getElementById("DnsID").value= beforeDnsID
       document.getElementById("dnsIdLabel").innerHTML = "AccessKey ID"
       document.getElementById("dnsSecretLabel").innerHTML = "AccessKey Secret"
-      document.getElementById("dns_help").innerHTML = "<a target='_blank' href='https://console.bce.baidu.com/iam/?_=1651763238057#/iam/accesslist'>创建 AccessKey</a><br /><a target='_blank' href='https://ticket.bce.baidu.com/#/ticket/create~productId=60&questionId=393&channel=2'>申请工单</a> ddns需调用api，而百度云相关api仅对申请用户开放，使用前请先提交工单申请。"
+      document.getElementById("dns_help").innerHTML = "<a target='_blank' href='https://console.bce.baidu.com/iam/?_=1651763238057#/iam/accesslist'>创建 AccessKey</a><br /><a target='_blank' href='https://ticket.bce.baidu.com/#/ticket/create~productId=60&questionId=393&channel=2'>申请工单</a> DDNS 需调用 API ，而百度云相关 API 仅对申请用户开放，使用前请先提交工单申请。"
     }
 
     var dnsName = '{{$.DNS.Name}}'
@@ -455,9 +455,9 @@
     $("#"+label+"_url").css("display", "block")
 
     if (label === "ipv4") {
-      $("#ipv4_url_help").html("支持多个接口, 使用半角逗号分隔。如: https://myip4.ipip.net, https://ddns.oray.com/checkip, https://ip.3322.net")
+      $("#ipv4_url_help").html("支持多个接口, 使用半角逗号分隔。如： https://myip4.ipip.net, https://ddns.oray.com/checkip, https://ip.3322.net")
     } else {
-      $("#ipv6_url_help").html("支持多个接口, 使用半角逗号分隔。如: https://myip6.ipip.net, https://speed.neu6.edu.cn/getIP.php, https://v6.ident.me")
+      $("#ipv6_url_help").html("支持多个接口, 使用半角逗号分隔。如： https://myip6.ipip.net, https://speed.neu6.edu.cn/getIP.php, https://v6.ident.me")
       $("#IPv6RegDiv").css("display", "none")
     }
   }
@@ -467,9 +467,9 @@
     $("#"+label+"_url").css("display", "none")
     $("#"+label+"_netInterface_select").css("display", "block")
     if (label === "ipv4") {
-      $("#ipv4_url_help").html("通过网卡获取IP, 建议在多宽带的路由器中使用")
+      $("#ipv4_url_help").html("通过网卡获取 IP , 建议在多宽带的路由器中使用")
     } else {
-      $("#ipv6_url_help").html("通过网卡获取IP, 如不指定匹配正则表达式, 将默认使用第一个IPv6地址")
+      $("#ipv6_url_help").html("通过网卡获取 IP , 如不指定匹配正则表达式, 将默认使用第一个 IPv6 地址")
       $("#IPv6RegDiv").removeAttr("style")
     }
 


### PR DESCRIPTION
允许用户在 Domains 输入框通过以冒号分隔的形式手动设置主机记录和主域名，这对于用户只拥有子域名管理权时非常有效。