### PR TITLE
feat: allow manually specify the RecordId of a domain name resolution

### DIFF
--- a/config/domains.go
+++ b/config/domains.go
@@ -25,6 +25,7 @@ type Domains struct {
 type Domain struct {
 	DomainName   string
 	SubDomain    string
+	RecordID     string
 	UpdateStatus updateStatusType // 更新状态
 }
 
@@ -123,6 +124,7 @@ func checkParseDomains(domainArr []string) (domains []*Domain) {
 					domain.SubDomain = domainStr[:domainLen]
 				}
 
+				domain.RecordID = ""
 				domains = append(domains, domain)
 			} else if dplen == 2 { // 主机记录:域名 格式
 				domain := &Domain{}
@@ -134,6 +136,19 @@ func checkParseDomains(domainArr []string) (domains []*Domain) {
 				}
 				domain.DomainName = dp[1]
 				domain.SubDomain = dp[0]
+				domain.RecordID = ""
+				domains = append(domains, domain)
+			} else if dplen == 3 { // RecordID:主机记录:域名 格式
+				domain := &Domain{}
+				sp := strings.Split(dp[2], ".")
+				length := len(sp)
+				if length <= 1 {
+					log.Println(domainStr, "域名不正确")
+					continue
+				}
+				domain.DomainName = dp[2]
+				domain.SubDomain = dp[1]
+				domain.RecordID = dp[0]
 				domains = append(domains, domain)
 			} else {
 				log.Println(domainStr, "域名不正确")

--- a/web/writing.html
+++ b/web/writing.html
@@ -134,7 +134,7 @@
 {{$v}}
 {{- end -}}
                   </textarea>
-                  <small id="ipv4_domains_help" class="form-text text-muted">一行一个域名, 可使用冒号手动分隔主机记录, 如： ddns.example.com, ddns:example.com</small>
+                  <small id="ipv4_domains_help" class="form-text text-muted">一行一个域名, 可使用冒号手动分隔主机记录或 RecordId （仅支持 阿里云）, 如： ddns.example.com, ddns:example.com, 2123:ddns:example.com</small>
                 </div>
               </div>
 
@@ -185,7 +185,7 @@
 {{$v}}
 {{- end -}}
                   </textarea>
-                  <small id="ipv6_domains_help" class="form-text text-muted">一行一个域名, 可使用冒号手动分隔主机记录, 如： ddns.example.com, ddns:example.com</small>
+                  <small id="ipv6_domains_help" class="form-text text-muted">一行一个域名, 可使用冒号手动分隔主机记录或 RecordId （仅支持 阿里云）, 如： ddns.example.com, ddns:example.com, 2123:ddns:example.com</small>
                 </div>
               </div>
 


### PR DESCRIPTION
允许用户在 Domains 输入框通过以冒号分隔的形式手动设置 RecordId ，这对于相同主机记录对应多 IP 实现负载均衡很有效。
目前只做了 阿里云 的适配，其他平台不支持此操作，会自动退化到只修改一个解析记录的状态。
阿里云 RecordId 可通过 阿里云 -> 解析设置 -> F12 调试 -> 网络 -> list.json -> 预览 -> data 获取。
Domains 中只要按 RecordId:ddns:example.com 格式填就好了。