### PR TITLE
Draft: Support update vm guest IP when work as PVE host

### DIFF
--- a/config/pveInterface.go
+++ b/config/pveInterface.go
@@ -35,8 +35,6 @@ type PveJson struct {
 // 传入虚拟机vmID，返回ipv4, ipv6地址
 func GetPveInterface(vmID string) (ipv4PveInterfaces []NetInterface, ipv6PveInterfaces []NetInterface, err error) {
 
-	//vmID := "100"
-
 	data := PveJson{}
 
 	_, err = exec.LookPath("pvesh")
@@ -98,19 +96,6 @@ func GetPveInterface(vmID string) (ipv4PveInterfaces []NetInterface, ipv6PveInte
 		}
 
 	}
-
-	//for i := 0; i < len(data.Result); i++ {
-	//	println(data.Result[i].Name + ":")
-	//	for j := 0; j < len(data.Result[i].IPAddresses); j++ {
-	//		if data.Result[i].IPAddresses[j].IPAddressType == "ipv4" {
-	//			print("ipv4\t")
-	//			println(data.Result[i].IPAddresses[j].IPAddress)
-	//		} else if data.Result[i].IPAddresses[j].IPAddressType == "ipv6" {
-	//			print("ipv6\t")
-	//			println(data.Result[i].IPAddresses[j].IPAddress)
-	//		}
-	//	}
-	//}
 
 	return ipv4PveInterfaces, ipv6PveInterfaces, nil
 }

--- a/config/pveInterface.go
+++ b/config/pveInterface.go
@@ -1,0 +1,116 @@
+package config
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"runtime"
+)
+
+// PveJson pvesh返回Json
+type PveJson struct {
+	Result []struct {
+		HardwareAddress string `json:"hardware-address"`
+		IPAddresses     []struct {
+			IPAddress     string `json:"ip-address"`
+			IPAddressType string `json:"ip-address-type"`
+			Prefix        int    `json:"prefix"`
+		} `json:"ip-addresses"`
+		Name       string `json:"name"`
+		Statistics struct {
+			RxBytes   int `json:"rx-bytes"`
+			RxDropped int `json:"rx-dropped"`
+			RxErrs    int `json:"rx-errs"`
+			RxPackets int `json:"rx-packets"`
+			TxBytes   int `json:"tx-bytes"`
+			TxDropped int `json:"tx-dropped"`
+			TxErrs    int `json:"tx-errs"`
+			TxPackets int `json:"tx-packets"`
+		} `json:"statistics"`
+	} `json:"result"`
+}
+
+// GetPveInterface 获取PVE客户机网卡地址
+// 传入虚拟机vmID，返回ipv4, ipv6地址
+func GetPveInterface(vmID string) (ipv4PveInterfaces []NetInterface, ipv6PveInterfaces []NetInterface, err error) {
+
+	//vmID := "100"
+
+	data := PveJson{}
+
+	_, err = exec.LookPath("pvesh")
+	if (runtime.GOOS != "linux") || (err != nil) {
+		fmt.Println("PVE模式不支持在非Proxmox Virtual Environment系统运行！")
+		return ipv4PveInterfaces, ipv6PveInterfaces, err
+	}
+
+	pve := exec.Command(
+		"pvesh", "get",
+		"nodes/pve/qemu/"+vmID+"/agent/network-get-interfaces",
+		"--output-format",
+		"json",
+	)
+	var bufferOut, bufferErr bytes.Buffer
+	pve.Stdout = &bufferOut
+	pve.Stderr = &bufferErr
+	err = pve.Run()
+	if err != nil {
+		fmt.Printf("pvesh运行错误:%v\n", err)
+	}
+
+	err = json.Unmarshal(bufferOut.Bytes(), &data)
+	if err != nil {
+		return ipv4PveInterfaces, ipv6PveInterfaces, err
+	}
+
+	for i := 0; i < len(data.Result); i++ {
+		var ipv4 []string
+		var ipv6 []string
+
+		for j := 0; j < len(data.Result[i].IPAddresses); j++ {
+			if data.Result[i].IPAddresses[j].IPAddressType == "ipv4" {
+				ipv4 = append(ipv4, data.Result[i].IPAddresses[j].IPAddress)
+			}
+			if data.Result[i].IPAddresses[j].IPAddressType == "ipv6" {
+				ipv6 = append(ipv6, data.Result[i].IPAddresses[j].IPAddress)
+			}
+		}
+
+		if len(ipv4) != 0 {
+			ipv4PveInterfaces = append(
+				ipv4PveInterfaces,
+				NetInterface{
+					Name:    data.Result[i].Name,
+					Address: ipv4,
+				},
+			)
+		}
+
+		if len(ipv6) != 0 {
+			ipv6PveInterfaces = append(
+				ipv6PveInterfaces,
+				NetInterface{
+					Name:    data.Result[i].Name,
+					Address: ipv6,
+				},
+			)
+		}
+
+	}
+
+	//for i := 0; i < len(data.Result); i++ {
+	//	println(data.Result[i].Name + ":")
+	//	for j := 0; j < len(data.Result[i].IPAddresses); j++ {
+	//		if data.Result[i].IPAddresses[j].IPAddressType == "ipv4" {
+	//			print("ipv4\t")
+	//			println(data.Result[i].IPAddresses[j].IPAddress)
+	//		} else if data.Result[i].IPAddresses[j].IPAddressType == "ipv6" {
+	//			print("ipv6\t")
+	//			println(data.Result[i].IPAddresses[j].IPAddress)
+	//		}
+	//	}
+	//}
+
+	return ipv4PveInterfaces, ipv6PveInterfaces, nil
+}

--- a/config/pveInterface_test.go
+++ b/config/pveInterface_test.go
@@ -1,0 +1,13 @@
+package config
+
+import (
+	"testing"
+)
+
+func TestGetPveInterface(t *testing.T) {
+	ipv4PveInterfaces, ipv6PveInterfaces, err := GetPveInterface("100")
+	if err != nil {
+		t.Error(err)
+	}
+	t.Log(ipv4PveInterfaces, ipv6PveInterfaces)
+}


### PR DESCRIPTION
Proxmox VE(后简称PVE) 是一个虚拟化设备管理平台。此PR尝试新增一种IP地址获取方式：允许当程序运行在PVE宿主机上时，通过pvesh获取指定客户机的IP地址来更新DNS。这对于PVE用户来说是极为方便的，只需要在宿主机上安装一个DDNS-GO就能更新所有 有需要的虚拟机的地址

由于PVE使用场景往往需要对多台设备进行DDNS，局限目前的结构，一个IPv4一个IPv6肯定是不够的，配置文件结构可能需要破坏旧版本兼容的改动。我只实现了接口，网页和配置未作修改<del>（能力有限，不太会）</del>。也可以讨论是否有更好的方案

我目前的构想是将IPv4和IPv6的块完全删除，改成一个个单元。默认自带一个IPv4和IPv6单元。单元的数量可以自由增删，在单元中确定IPv4、IPv6，IP获取方式和虚拟机VMID，结构样例：

```
type Config struct {
	Unit []struct {
		Enable       bool     // 是否启用
		Name         string   // Unit名称
		NetType      string   // 网络类型 ipv4/ipv6
		GetType      string   // 获取IP类型 url/netInterface/pveInterface
		URL          string   // 接口方式获取URL
		NetInterface string   // 网卡获取方式
		VmID         string   // PVE模式虚拟机ID
		PveInterface string   // PVE模式网卡
		IPv6Reg      string   // IPv6匹配正则表达式
		Domains      []string // 域名
	}
	DNS DNSConfig
	User
	Webhook
	// 禁止公网访问
	NotAllowWanAccess bool
	TTL               string
}
```
