### PR TITLE
build(docker): slim Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,19 +3,19 @@ FROM golang:1.18 AS builder
 
 WORKDIR /app
 COPY . .
-RUN go env -w GO111MODULE=on \
-    && go env -w GOPROXY=https://goproxy.cn,direct \
-    && make clean build
+ENV GO111MODULE=on
+ENV GOPROXY=https://goproxy.cn,direct
+RUN make clean build
 
 # final stage
-FROM alpine
+FROM scratch
 LABEL name=ddns-go
 LABEL url=https://github.com/jeessy2/ddns-go
 
 WORKDIR /app
-RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.tuna.tsinghua.edu.cn/g' /etc/apk/repositories \
-    && apk add --no-cache tzdata
 ENV TZ=Asia/Shanghai
+COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=builder /app/ddns-go /app/ddns-go
 EXPOSE 9876
 ENTRYPOINT ["/app/ddns-go"]


### PR DESCRIPTION
Use [`scratch`](https://hub.docker.com/_/scratch) as runner to reduce the size of Docker image.

The size reduced by about 5 MB:

![image](https://user-images.githubusercontent.com/15844309/182014498-65991209-d46f-42f5-ae4a-5e19f5703bdc.png)
