### PR TITLE
fix: use tcp6 when get ipv6 from api

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -147,7 +147,7 @@ func (conf *Config) GetIpv4Addr() (result string) {
 		return
 	}
 
-	client := util.CreateNoProxyHTTPClient()
+	client := util.CreateNoProxyHTTPClient("tcp4")
 	urls := strings.Split(conf.Ipv4.URL, ",")
 	for _, url := range urls {
 		url = strings.TrimSpace(url)
@@ -207,7 +207,7 @@ func (conf *Config) GetIpv6Addr() (result string) {
 		return
 	}
 
-	client := util.CreateNoProxyHTTPClient()
+	client := util.CreateNoProxyHTTPClient("tcp6")
 	urls := strings.Split(conf.Ipv6.URL, ",")
 	for _, url := range urls {
 		url = strings.TrimSpace(url)

--- a/util/http_client_util.go
+++ b/util/http_client_util.go
@@ -15,26 +15,54 @@ func CreateHTTPClient() *http.Client {
 	}
 }
 
-var dialer = &net.Dialer{
+var noProxyDialer = &net.Dialer{
 	Timeout:   30 * time.Second,
 	KeepAlive: 30 * time.Second,
 }
 
-// CreateNoProxyHTTPClient CreateNoProxyHTTPClient
-func CreateNoProxyHTTPClient() *http.Client {
+var noProxyTcp4Transport = &http.Transport{
+	// no proxy
+	// DisableKeepAlives
+	DisableKeepAlives: true,
+	// tcp4
+	DialContext: func(ctx context.Context, network, address string) (net.Conn, error) {
+		return noProxyDialer.DialContext(ctx, "tcp4", address)
+	},
+	// from http.DefaultTransport
+	ForceAttemptHTTP2:     true,
+	MaxIdleConns:          100,
+	IdleConnTimeout:       90 * time.Second,
+	TLSHandshakeTimeout:   10 * time.Second,
+	ExpectContinueTimeout: 1 * time.Second,
+}
+
+var noProxyTcp6Transport = &http.Transport{
+	// no proxy
+	// DisableKeepAlives
+	DisableKeepAlives: true,
+	// tcp6
+	DialContext: func(ctx context.Context, network, address string) (net.Conn, error) {
+		return noProxyDialer.DialContext(ctx, "tcp6", address)
+	},
+	// from http.DefaultTransport
+	ForceAttemptHTTP2:     true,
+	MaxIdleConns:          100,
+	IdleConnTimeout:       90 * time.Second,
+	TLSHandshakeTimeout:   10 * time.Second,
+	ExpectContinueTimeout: 1 * time.Second,
+}
+
+// CreateNoProxyHTTPClient Create NoProxy HTTP Client
+func CreateNoProxyHTTPClient(network string) *http.Client {
+	if network == "tcp6" {
+		return &http.Client{
+			Timeout:   30 * time.Second,
+			Transport: noProxyTcp6Transport,
+		}
+	}
+
 	return &http.Client{
-		Timeout: 30 * time.Second,
-		Transport: &http.Transport{
-			// no proxy
-			// from http.DefaultTransport
-			DialContext: func(ctx context.Context, network, address string) (net.Conn, error) {
-				return dialer.DialContext(ctx, network, address)
-			},
-			ForceAttemptHTTP2:     true,
-			MaxIdleConns:          100,
-			IdleConnTimeout:       90 * time.Second,
-			TLSHandshakeTimeout:   10 * time.Second,
-			ExpectContinueTimeout: 1 * time.Second,
-		},
+		Timeout:   30 * time.Second,
+		Transport: noProxyTcp4Transport,
 	}
 }


### PR DESCRIPTION
fix: #347