### PR TITLE
build: correct the module path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ddns-go
 
-[![GitHub release](https://img.shields.io/github/release/jeessy2/ddns-go.svg?logo=github&style=flat-square)](https://github.com/jeessy2/ddns-go/releases/latest) [![](https://goreportcard.com/badge/github.com/jeessy2/ddns-go)](https://goreportcard.com/report/github.com/jeessy2/ddns-go) [![](https://img.shields.io/docker/image-size/jeessy/ddns-go)](https://registry.hub.docker.com/r/jeessy/ddns-go) [![](https://img.shields.io/docker/pulls/jeessy/ddns-go)](https://registry.hub.docker.com/r/jeessy/ddns-go)
+[![GitHub release](https://img.shields.io/github/release/jeessy2/ddns-go.svg?logo=github&style=flat-square)](https://github.com/jeessy2/ddns-go/releases/latest) [![](https://goreportcard.com/badge/github.com/jeessy2/ddns-go/v4)](https://goreportcard.com/report/github.com/jeessy2/ddns-go/v4) [![](https://img.shields.io/docker/image-size/jeessy/ddns-go)](https://registry.hub.docker.com/r/jeessy/ddns-go) [![](https://img.shields.io/docker/pulls/jeessy/ddns-go)](https://registry.hub.docker.com/r/jeessy/ddns-go)
 
 自动获得你的公网 IPv4 或 IPv6 地址，并解析到对应的域名服务。
 

--- a/config/config.go
+++ b/config/config.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"ddns-go/util"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -10,6 +9,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/jeessy2/ddns-go/v4/util"
 	"gopkg.in/yaml.v2"
 )
 

--- a/config/domains.go
+++ b/config/domains.go
@@ -1,10 +1,11 @@
 package config
 
 import (
-	"ddns-go/util"
 	"log"
 	"net/url"
 	"strings"
+
+	"github.com/jeessy2/ddns-go/v4/util"
 )
 
 // 固定的主域名

--- a/config/webhook.go
+++ b/config/webhook.go
@@ -1,13 +1,14 @@
 package config
 
 import (
-	"ddns-go/util"
 	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
 	"net/url"
 	"strings"
+
+	"github.com/jeessy2/ddns-go/v4/util"
 )
 
 // Webhook Webhook

--- a/dns/alidns.go
+++ b/dns/alidns.go
@@ -2,11 +2,12 @@ package dns
 
 import (
 	"bytes"
-	"ddns-go/config"
-	"ddns-go/util"
 	"log"
 	"net/http"
 	"net/url"
+
+	"github.com/jeessy2/ddns-go/v4/config"
+	"github.com/jeessy2/ddns-go/v4/util"
 )
 
 const (

--- a/dns/baidu.go
+++ b/dns/baidu.go
@@ -2,12 +2,13 @@ package dns
 
 import (
 	"bytes"
-	"ddns-go/config"
-	"ddns-go/util"
 	"encoding/json"
 	"log"
 	"net/http"
 	"strconv"
+
+	"github.com/jeessy2/ddns-go/v4/config"
+	"github.com/jeessy2/ddns-go/v4/util"
 )
 
 // https://cloud.baidu.com/doc/BCD/s/4jwvymhs7

--- a/dns/callback.go
+++ b/dns/callback.go
@@ -1,14 +1,15 @@
 package dns
 
 import (
-	"ddns-go/config"
-	"ddns-go/util"
 	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
 	"net/url"
 	"strings"
+
+	"github.com/jeessy2/ddns-go/v4/config"
+	"github.com/jeessy2/ddns-go/v4/util"
 )
 
 type Callback struct {

--- a/dns/cloudflare.go
+++ b/dns/cloudflare.go
@@ -2,13 +2,14 @@ package dns
 
 import (
 	"bytes"
-	"ddns-go/config"
-	"ddns-go/util"
 	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
 	"strconv"
+
+	"github.com/jeessy2/ddns-go/v4/config"
+	"github.com/jeessy2/ddns-go/v4/util"
 )
 
 const (

--- a/dns/dnspod.go
+++ b/dns/dnspod.go
@@ -1,11 +1,12 @@
 package dns
 
 import (
-	"ddns-go/config"
-	"ddns-go/util"
 	"log"
 	"net/http"
 	"net/url"
+
+	"github.com/jeessy2/ddns-go/v4/config"
+	"github.com/jeessy2/ddns-go/v4/util"
 )
 
 const (

--- a/dns/huawei.go
+++ b/dns/huawei.go
@@ -2,13 +2,14 @@ package dns
 
 import (
 	"bytes"
-	"ddns-go/config"
-	"ddns-go/util"
 	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
 	"strconv"
+
+	"github.com/jeessy2/ddns-go/v4/config"
+	"github.com/jeessy2/ddns-go/v4/util"
 )
 
 const (

--- a/dns/index.go
+++ b/dns/index.go
@@ -1,9 +1,10 @@
 package dns
 
 import (
-	"ddns-go/config"
 	"log"
 	"time"
+
+	"github.com/jeessy2/ddns-go/v4/config"
 )
 
 // DNS interface

--- a/dns/porkbun.go
+++ b/dns/porkbun.go
@@ -2,12 +2,13 @@ package dns
 
 import (
 	"bytes"
-	"ddns-go/config"
-	"ddns-go/util"
 	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
+
+	"github.com/jeessy2/ddns-go/v4/config"
+	"github.com/jeessy2/ddns-go/v4/util"
 )
 
 const (

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module ddns-go
+module github.com/jeessy2/ddns-go/v4
 
 go 1.18
 

--- a/main.go
+++ b/main.go
@@ -1,10 +1,6 @@
 package main
 
 import (
-	"ddns-go/config"
-	"ddns-go/dns"
-	"ddns-go/util"
-	"ddns-go/web"
 	"embed"
 	"flag"
 	"fmt"
@@ -17,6 +13,10 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/jeessy2/ddns-go/v4/config"
+	"github.com/jeessy2/ddns-go/v4/dns"
+	"github.com/jeessy2/ddns-go/v4/util"
+	"github.com/jeessy2/ddns-go/v4/web"
 	"github.com/kardianos/service"
 )
 

--- a/web/basic_auth.go
+++ b/web/basic_auth.go
@@ -2,13 +2,14 @@ package web
 
 import (
 	"bytes"
-	"ddns-go/config"
-	"ddns-go/util"
 	"encoding/base64"
 	"log"
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/jeessy2/ddns-go/v4/config"
+	"github.com/jeessy2/ddns-go/v4/util"
 )
 
 // ViewFunc func

--- a/web/netInterfaces.go
+++ b/web/netInterfaces.go
@@ -1,9 +1,10 @@
 package web
 
 import (
-	"ddns-go/config"
 	"encoding/json"
 	"net/http"
+
+	"github.com/jeessy2/ddns-go/v4/config"
 )
 
 // Ipv4NetInterfaces 获得Ipv4网卡信息

--- a/web/save.go
+++ b/web/save.go
@@ -1,11 +1,12 @@
 package web
 
 import (
-	"ddns-go/config"
-	"ddns-go/dns"
-	"ddns-go/util"
 	"net/http"
 	"strings"
+
+	"github.com/jeessy2/ddns-go/v4/config"
+	"github.com/jeessy2/ddns-go/v4/dns"
+	"github.com/jeessy2/ddns-go/v4/util"
 )
 
 // Save 保存

--- a/web/webhookTest.go
+++ b/web/webhookTest.go
@@ -1,10 +1,11 @@
 package web
 
 import (
-	"ddns-go/config"
 	"log"
 	"net/http"
 	"strings"
+
+	"github.com/jeessy2/ddns-go/v4/config"
 )
 
 // WebhookTest 测试webhook

--- a/web/writing.go
+++ b/web/writing.go
@@ -1,14 +1,14 @@
 package web
 
 import (
-	"ddns-go/config"
 	"embed"
-	"os"
-	"strings"
-
 	"fmt"
 	"html/template"
 	"net/http"
+	"os"
+	"strings"
+
+	"github.com/jeessy2/ddns-go/v4/config"
 )
 
 //go:embed writing.html


### PR DESCRIPTION
For a published module, we should use `repo`'s url as the module path, so we can download or refer it by go module.

And for we are in v4.x, so we should add the `/v4` suffix to the module path.

## Reference

<https://go.dev/doc/tutorial/create-module#start>:

> Run the go mod init command, giving it your module path -- here, use `example.com/greetings`. If you publish a module, this must be a path from which your module can be downloaded by Go tools. That would be your code's repository.