### PR TITLE
refactor: update dependency and use build-in function

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -10,7 +10,7 @@ import (
 	"sync"
 
 	"github.com/jeessy2/ddns-go/v4/util"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 // Ipv4Reg IPv4正则

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,7 @@ go 1.19
 
 require (
 	github.com/kardianos/service v1.2.1
-	github.com/mitchellh/go-homedir v1.1.0
-	gopkg.in/yaml.v2 v2.4.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require golang.org/x/sys v0.0.0-20220730100132-1609e554cd39 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,11 +1,9 @@
 github.com/kardianos/service v1.2.1 h1:AYndMsehS+ywIS6RB9KOlcXzteWUzxgMgBymJD7+BYk=
 github.com/kardianos/service v1.2.1/go.mod h1:CIMRFEJVL+0DS1a3Nx06NaMn4Dz63Ng6O7dl0qH0zVM=
-github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
-github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 golang.org/x/sys v0.0.0-20201015000850-e3ed0017c211/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20220730100132-1609e554cd39 h1:aNCnH+Fiqs7ZDTFH6oEFjIfbX2HvgQXJ6uQuUbTobjk=
 golang.org/x/sys v0.0.0-20220730100132-1609e554cd39/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
-gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/util/user.go
+++ b/util/user.go
@@ -3,8 +3,6 @@ package util
 import (
 	"log"
 	"os"
-
-	"github.com/mitchellh/go-homedir"
 )
 
 const ConfigFilePathENV = "DDNS_CONFIG_FILE_PATH"
@@ -20,7 +18,7 @@ func GetConfigFilePath() string {
 
 // GetConfigFilePathDefault 获得默认的配置文件路径
 func GetConfigFilePathDefault() string {
-	dir, err := homedir.Dir()
+	dir, err := os.UserHomeDir()
 	if err != nil {
 		log.Println("Geting current user failed!")
 		return "../.ddns_go_config.yaml"


### PR DESCRIPTION
The `os.UserHomeDir` is added since [go 1.12](https://pkg.go.dev/os#UserHomeDir).