### PR TITLE
feat: faster Docker multi-platform builds and shrink Go binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ DIR_SRC=.
 DOCKER_CMD=docker
 
 GO_ENV=CGO_ENABLED=0
-GO_FLAGS=-ldflags="-X main.version=$(VERSION) -X 'main.buildTime=`date`' -extldflags -static" -trimpath
+GO_FLAGS=-ldflags="-X main.version=$(VERSION) -X 'main.buildTime=`date`' -extldflags -static -s -w" -trimpath
 GO=$(GO_ENV) $(shell which go)
 GOROOT=$(shell `which go` env GOROOT)
 GOPATH=$(shell `which go` env GOPATH)


### PR DESCRIPTION
For faster Docker multi-platform builds, see 4067132 and https://www.docker.com/blog/faster-multi-platform-builds-dockerfile-cross-compilation-guide/

For shrink Go binaries, see 01d392d and https://pkg.go.dev/cmd/link