### PR TITLE
fix: goreleaser deprecates --rm-dist and archives.replacements

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,6 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -35,12 +35,20 @@ builds:
     ldflags:
       - -s -w -X main.version={{.Tag}} -X main.buildTime={{.Date}}
 archives:
-  - replacements:
-      darwin: Darwin
-      linux: Linux
-      windows: Windows
-      386: i386
-      amd64: x86_64
+    # use zip for windows archives
+  - format_overrides:
+      - goos: windows
+        format: zip
+    # this name template makes the OS and Arch compatible with the results of uname.
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- .Version }}_
+      {{- .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Mips }}_{{ .Mips }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
 checksum:
   name_template: 'checksums.txt'
 snapshot:


### PR DESCRIPTION
GoReleaser's `--rm-dist` and `archives.replacements` has been deprecated.

See https://goreleaser.com/deprecations/#-rm-dist and https://goreleaser.com/deprecations/#archivesreplacements