### PR TITLE
fix(goreleaser.yml): forget capitalize the first letter of .Os

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -43,10 +43,7 @@ archives:
     name_template: >-
       {{ .ProjectName }}_
       {{- .Version }}_
-      {{- if eq .Os "darwin" }}Darwin
-      {{- else if eq .Os "linux" }}Linux
-      {{- else if eq .Os "windows" }}Windows
-      {{- else }}{{ .Os }}{{ end }}_
+      {{- title .Os }}_
       {{- if eq .Arch "amd64" }}x86_64
       {{- else if eq .Arch "386" }}i386
       {{- else }}{{ .Arch }}{{ end }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -43,7 +43,10 @@ archives:
     name_template: >-
       {{ .ProjectName }}_
       {{- .Version }}_
-      {{- .Os }}_
+      {{- if eq .Os "darwin" }}Darwin
+      {{- else if eq .Os "linux" }}Linux
+      {{- else if eq .Os "windows" }}Windows
+      {{- else }}{{ .Os }}{{ end }}_
       {{- if eq .Arch "amd64" }}x86_64
       {{- else if eq .Arch "386" }}i386
       {{- else }}{{ .Arch }}{{ end }}


### PR DESCRIPTION
Forget to capitalize the first letter of `.Os`. 

It should now like [v4.4.2](https://github.com/jeessy2/ddns-go/releases/tag/v4.4.2).

Sorry.