### PR TITLE
fix(make): build_docker_image failed [skip ci]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /app
 COPY . .
 ARG TARGETOS TARGETARCH
 
-RUN apk add git make tzdata \
+RUN apk add --no-cache git make tzdata \
     && GOOS=$TARGETOS GOARCH=$TARGETARCH make clean build
 
 # final stage

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,8 @@
 VERSION=$(shell git describe --tags `git rev-list --tags --max-count=1`)
 BIN=ddns-go
 DIR_SRC=.
-DOCKER_CMD=docker
+DOCKER_ENV=DOCKER_BUILDKIT=1
+DOCKER=$(DOCKER_ENV) docker
 
 GO_ENV=CGO_ENABLED=0
 GO_FLAGS=-ldflags="-X main.version=$(VERSION) -X 'main.buildTime=`date`' -extldflags -static -s -w" -trimpath
@@ -15,7 +16,7 @@ build: $(DIR_SRC)/main.go
 	@$(GO) build $(GO_FLAGS) -o $(BIN) $(DIR_SRC)
 
 build_docker_image:
-	@$(DOCKER_CMD) build -f ./Dockerfile -t ddns-go:$(VERSION) .
+	@$(DOCKER) build -f ./Dockerfile -t ddns-go:$(VERSION) .
 
 test:
 	@$(GO) test ./...


### PR DESCRIPTION
If you try to run `make build_docker_image` on a machine without buildkit enabled, it will output:
```
Sending build context to Docker daemon  696.3kB
Step 1/15 : FROM --platform=$BUILDPLATFORM golang:1.19-alpine AS builder
failed to parse platform : "" is an invalid component of "": platform specifier component must match "^[A-Za-z0-9_-]+$": invalid argument
make: *** [Makefile:18: build_docker_image] Error 1
```

Looks like it fails after #498 because it requires buildkit, add `DOCKER_BUILDKIT=1` to enable buildkit to fix this.

Also, add `--no-cache` to `apk add` to not cache the index locally, forgot to do that in #498.