### PR TITLE
chore(CI): getting Go version from the `go.mod` file

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19
+          go-version-file: 'go.mod'
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19
+          go-version-file: 'go.mod'
 
       - name: Test
         run: make build test


### PR DESCRIPTION
# 描述
Getting Go version from the `go.mod` file.

See: https://github.com/actions/setup-go#getting-go-version-from-the-gomod-file

# 提交类型
- [ ] 修复
- [ ] 功能
- [ ] 文档
- [x] 其它
