### PR TITLE
feat: If the configuration is empty and after two days, access to the web from the Internet is not allowed

### DIFF
--- a/web/basic_auth.go
+++ b/web/basic_auth.go
@@ -30,6 +30,7 @@ func BasicAuth(f ViewFunc) ViewFunc {
 		if err != nil && time.Now().Unix()-startTime > 2*24*60*60 &&
 			(!util.IsPrivateNetwork(r.RemoteAddr) || !util.IsPrivateNetwork(r.Host)) {
 			w.WriteHeader(http.StatusForbidden)
+			log.Printf("配置文件为空, 超过2天禁止从公网访问。RemoteAddr: %s\n", r.RemoteAddr)
 			return
 		}
 
@@ -37,6 +38,7 @@ func BasicAuth(f ViewFunc) ViewFunc {
 		if conf.NotAllowWanAccess {
 			if !util.IsPrivateNetwork(r.RemoteAddr) || !util.IsPrivateNetwork(r.Host) {
 				w.WriteHeader(http.StatusForbidden)
+				log.Printf("%s 被禁止从公网访问\n", r.RemoteAddr)
 				return
 			}
 		}

--- a/web/basic_auth.go
+++ b/web/basic_auth.go
@@ -24,7 +24,14 @@ var ld = &loginDetect{}
 // BasicAuth basic auth
 func BasicAuth(f ViewFunc) ViewFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		conf, _ := config.GetConfigCache()
+		conf, err := config.GetConfigCache()
+
+		// 配置文件为空, 超过2天禁止从公网访问
+		if err != nil && time.Now().Unix()-startTime > 2*24*60*60 &&
+			(!util.IsPrivateNetwork(r.RemoteAddr) || !util.IsPrivateNetwork(r.Host)) {
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
 
 		// 禁止公网访问
 		if conf.NotAllowWanAccess {


### PR DESCRIPTION
# What does this PR do?
如配置文件为空, 超过2天禁止从公网访问页面
防止网络空间测绘

# Motivation

# Additional Notes
