### PR TITLE
fix: If getting user home with error, don't display the logs

### DIFF
--- a/util/user.go
+++ b/util/user.go
@@ -1,7 +1,6 @@
 package util
 
 import (
-	"log"
 	"os"
 )
 
@@ -20,7 +19,7 @@ func GetConfigFilePath() string {
 func GetConfigFilePathDefault() string {
 	dir, err := os.UserHomeDir()
 	if err != nil {
-		log.Println("Geting current user failed!")
+		// log.Println("Geting current user failed!", err)
 		return "../.ddns_go_config.yaml"
 	}
 	return dir + string(os.PathSeparator) + ".ddns_go_config.yaml"


### PR DESCRIPTION
# What does this PR do?
获取用户目录失败时，不在显示失败日志

# Motivation

# Additional Notes
