### PR TITLE
fix: add environment HOME to service and revert #576 and #577

### DIFF
--- a/main.go
+++ b/main.go
@@ -166,12 +166,22 @@ func getService() service.Service {
 		options["SysvScript"] = sysvScript
 	}
 
+	dir, err := os.UserHomeDir()
+	if err != nil {
+		log.Println("Getting Home directory failed: ", err)
+	}
+
 	svcConfig := &service.Config{
 		Name:        "ddns-go",
 		DisplayName: "ddns-go",
 		Description: "简单好用的DDNS。自动更新域名解析到公网IP(支持阿里云、腾讯云dnspod、Cloudflare、华为云)",
-		Arguments:   []string{"-l", *listen, "-f", strconv.Itoa(*every), "-c", *configFilePath},
+		Arguments:   []string{"-l", *listen, "-f", strconv.Itoa(*every)},
 		Option:      options,
+		EnvVars:     map[string]string{"HOME": dir},
+	}
+
+	if *configFilePath != "" {
+		svcConfig.Arguments = append(svcConfig.Arguments, "-c", *configFilePath)
 	}
 
 	if *noWebService {

--- a/main.go
+++ b/main.go
@@ -180,7 +180,7 @@ func getService() service.Service {
 		EnvVars:     map[string]string{"HOME": dir},
 	}
 
-	if *configFilePath != "" {
+	if *configFilePath != util.GetConfigFilePathDefault() {
 		svcConfig.Arguments = append(svcConfig.Arguments, "-c", *configFilePath)
 	}
 

--- a/main.go
+++ b/main.go
@@ -174,7 +174,7 @@ func getService() service.Service {
 	svcConfig := &service.Config{
 		Name:        "ddns-go",
 		DisplayName: "ddns-go",
-		Description: "简单好用的DDNS。自动更新域名解析到公网IP(支持阿里云、腾讯云dnspod、Cloudflare、华为云)",
+		Description: "简单好用的DDNS。自动更新域名解析到公网IP(支持阿里云、腾讯云dnspod、Cloudflare、Callback、华为云、百度云、porkbun、GoDaddy、Google Domains)",
 		Arguments:   []string{"-l", *listen, "-f", strconv.Itoa(*every)},
 		Option:      options,
 		EnvVars:     map[string]string{"HOME": dir},

--- a/util/user.go
+++ b/util/user.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"log"
 	"os"
 )
 
@@ -19,7 +20,7 @@ func GetConfigFilePath() string {
 func GetConfigFilePathDefault() string {
 	dir, err := os.UserHomeDir()
 	if err != nil {
-		// log.Println("Geting current user failed!", err)
+		log.Println("Getting Home directory failed: ", err)
 		return "../.ddns_go_config.yaml"
 	}
 	return dir + string(os.PathSeparator) + ".ddns_go_config.yaml"


### PR DESCRIPTION
# What does this PR do?
Add environment `HOME` to service and revert #576 and "fix: If getting user home with error, don't display the logs (#577)".

Also, add config file path to the service only if it is not equal to the default config file path.

This should really fix #575.

Update the description of the service to the latest.

# Motivation
Add it because the environment `HOME` doesn't exist for systemd system service but ddns-go needs it.

Revert #576 and "fix: If getting user home with error, don't display the logs (#577)" because this is no longer an issue.

# Additional Notes
- [linux - How to use the `$HOME` environment variable in systemd service files - Server Fault](https://serverfault.com/questions/794922/how-to-use-the-home-environment-variable-in-systemd-service-files)
- [Using environment variables in systemd units | Flatcar Container Linux](https://www.flatcar.org/docs/latest/setup/systemd/environment-variables/)