### PR TITLE
chore: use Restricted Shell

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -192,7 +192,7 @@ func (conf *Config) getAddrFromCmd(addrType string) string {
 	if runtime.GOOS == "windows" {
 		execCmd = exec.Command("powershell", "-Command", cmd)
 	} else {
-		execCmd = exec.Command("sh", "-c", cmd)
+		execCmd = exec.Command("bash", "-rc", cmd)
 	}
 	// run cmd
 	out, err := execCmd.Output()


### PR DESCRIPTION
# What does this PR do?
Running commands with Restricted Shell.

# Motivation
The security of Shell is important, so use `bash -r` to limit the commands that the Shell can run.

# Additional Notes
- [The Restricted Shell (Bash Reference Manual)](https://www.gnu.org/software/bash/manual/html_node/The-Restricted-Shell.html)