### PR TITLE
fix: set default DNS server

### DIFF
--- a/util/http_client_util.go
+++ b/util/http_client_util.go
@@ -14,6 +14,12 @@ const SkipVerfiryENV = "DDNS_SKIP_VERIFY"
 var dialer = &net.Dialer{
 	Timeout:   30 * time.Second,
 	KeepAlive: 30 * time.Second,
+	Resolver: &net.Resolver{
+		PreferGo: true,
+		Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
+			return net.Dial("udp", "8.8.8.8:53") // DNS Protocol and Google Public DNS
+		},
+	},
 }
 
 var defaultTransport = &http.Transport{


### PR DESCRIPTION
# What does this PR do?
Set a default DNS server.

- Fix #587 and fix #589.

# Motivation
If the file `/etc/resolv.conf` does not exist for Unix, Go will use `127.0.0.1` or `::1` as the DNS server. Set a default DNS server to resolve the issue.

# Additional Notes
- fatedier/frp#700
- golang/go#8877
- https://gist.github.com/Integralist/8a9cb8924f75ae42487fd877b03360e2
- https://pkg.go.dev/net#Resolver

**The solution may not be good enough, sorry.**