### PR TITLE
deps: bump golang from 1.19 to 1.20

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,8 +14,3 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-
-  - package-ecosystem: "docker" # Docker
-    directory: "/"
-    schedule:
-      interval: "daily"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # build stage
-FROM --platform=$BUILDPLATFORM golang:1.19-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.20-alpine AS builder
 
 WORKDIR /app
 COPY . .

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jeessy2/ddns-go/v5
 
-go 1.19
+go 1.20
 
 require (
 	github.com/kardianos/service v1.2.2


### PR DESCRIPTION
# What does this PR do?
deps: bump golang from 1.19 to 1.20

# Motivation

# Additional Notes
