### PR TITLE
feat: Force compare when update fails

### DIFF
--- a/config/webhook.go
+++ b/config/webhook.go
@@ -34,6 +34,14 @@ func ExecWebhook(domains *Domains, conf *Config) {
 	v4Status := getDomainsStatus(domains.Ipv4Domains)
 	v6Status := getDomainsStatus(domains.Ipv6Domains)
 
+	if v4Status == UpdatedFailed || v6Status == UpdatedFailed {
+		// 有失败，需要强制比对
+		util.ForceCompare = true
+	} else {
+		// 否则，关闭强制对比
+		util.ForceCompare = false
+	}
+
 	if conf.WebhookURL != "" && (v4Status != UpdatedNothing || v6Status != UpdatedNothing) {
 		// 成功和失败都要触发webhook
 		method := "GET"

--- a/dns/index.go
+++ b/dns/index.go
@@ -70,5 +70,4 @@ func RunOnce() {
 		domains := dnsSelected.AddUpdateDomainRecords()
 		config.ExecWebhook(&domains, &conf)
 	}
-	util.ForceCompare = false
 }

--- a/util/http_util.go
+++ b/util/http_util.go
@@ -30,7 +30,6 @@ func GetHTTPResponse(resp *http.Response, url string, err error, result interfac
 func GetHTTPResponseOrg(resp *http.Response, url string, err error) ([]byte, error) {
 	if err != nil {
 		log.Printf("请求接口%s失败! ERROR: %s\n", url, err)
-		ForceCompare = true
 		return nil, err
 	}
 
@@ -38,7 +37,6 @@ func GetHTTPResponseOrg(resp *http.Response, url string, err error) ([]byte, err
 	body, err := io.ReadAll(resp.Body)
 
 	if err != nil {
-		ForceCompare = true
 		log.Printf("请求接口%s失败! ERROR: %s\n", url, err)
 	}
 


### PR DESCRIPTION
# What does this PR do?
以前：请求接口失败时
优化为：当状态为更新失败时，进行强制比对。

# Motivation
以前的强制比对有可能失效

# Additional Notes
