### PR TITLE
ci(docker): push to `ghcr.io`

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           images: |
             ${{ env.DOCKER_REPO }}
-            ghcr.io/${{ env.DOCKER_REPO }}
+            ghcr.io/${{ github.repository }}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker buildx
@@ -37,7 +37,7 @@ jobs:
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
-          username: jeessy2
+          username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Run buildx and push
         uses: docker/build-push-action@v4

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -12,7 +12,7 @@ jobs:
   buildx-dockerhub:
     runs-on: ubuntu-latest
     env:
-      DOCKER_REPO: jeessy/ddns-go
+      DOCKER_REPO: ${{ secrets.DOCKER_USERNAME }}/ddns-go
       DOCKER_PLATFORMS: linux/amd64,linux/arm,linux/arm64
     steps:
       - name: Checkout
@@ -21,16 +21,24 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: ${{ env.DOCKER_REPO }}
+          images: |
+            ${{ env.DOCKER_REPO }}
+            ghcr.io/${{ env.DOCKER_REPO }}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker buildx
         uses: docker/setup-buildx-action@v2
-      - name: Docker login # login to docker hub, automatically logout at the end of job
+      - name: Login to Docker Hub # login to Docker Hub, automatically logout at the end of job
         uses: docker/login-action@v2 
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: jeessy2
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Run buildx and push
         uses: docker/build-push-action@v4
         with:

--- a/.github/workflows/dockerhub-description.yml
+++ b/.github/workflows/dockerhub-description.yml
@@ -20,5 +20,5 @@ jobs:
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
-        repository: jeessy/ddns-go
+        repository: ${{ secrets.DOCKER_USERNAME }}/ddns-go
         short-description: ${{ github.event.repository.description }}

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@
 - [可选] 使用 `ghcr.io` 镜像
 
   ```bash
-  docker run -d --name ddns-go --restart=always --net=host -v /opt/ddns-go:/root ghcr.io/jeessy/ddns-go
+  docker run -d --name ddns-go --restart=always --net=host -v /opt/ddns-go:/root ghcr.io/jeessy2/ddns-go
   ```
 
 - [可选] 支持启动带参数 `-l`监听地址 `-f`间隔时间(秒)

--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@
 
 - 在浏览器中打开`http://主机IP:9876`，修改你的配置，成功
 
+- [可选] 使用 `ghcr.io` 镜像
+
+  ```bash
+  docker run -d --name ddns-go --restart=always --net=host -v /opt/ddns-go:/root ghcr.io/jeessy/ddns-go
+  ```
+
 - [可选] 支持启动带参数 `-l`监听地址 `-f`间隔时间(秒)
 
   ```bash


### PR DESCRIPTION
# What does this PR do?
Push the Docker Image to `ghcr.io`.

Closes #641.

# Motivation
Relying on Docker Hub alone is not reliable enough.[^1]

# Additional Notes
By adding the steps to login to `ghcr.io` and adding the `ghcr.io` image to do this.

Also, replaces text that can be replaced by secret with secret.

[^1]: https://www.docker.com/blog/we-apologize-we-did-a-terrible-job-announcing-the-end-of-docker-free-teams/