### PR TITLE
fix: If Bash does not exist, use sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,6 @@ LABEL name=ddns-go
 LABEL url=https://github.com/jeessy2/ddns-go
 
 WORKDIR /app
-RUN apk add --no-cache bash
 COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
 ENV TZ=Asia/Shanghai
 COPY --from=builder /app/ddns-go /app/ddns-go

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ LABEL name=ddns-go
 LABEL url=https://github.com/jeessy2/ddns-go
 
 WORKDIR /app
+RUN apk add --no-cache bash
 COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
 ENV TZ=Asia/Shanghai
 COPY --from=builder /app/ddns-go /app/ddns-go

--- a/config/config.go
+++ b/config/config.go
@@ -226,7 +226,13 @@ func (conf *DnsConfig) getAddrFromCmd(addrType string) string {
 	if runtime.GOOS == "windows" {
 		execCmd = exec.Command("powershell", "-Command", cmd)
 	} else {
-		execCmd = exec.Command("bash", "-rc", cmd)
+		// If Bash does not exist, use sh
+		_, err := exec.LookPath("bash")
+		if err != nil {
+			execCmd = exec.Command("sh", "-c", cmd)
+		} else {
+			execCmd = exec.Command("bash", "-rc", cmd)
+		}
 	}
 	// run cmd
 	out, err := execCmd.CombinedOutput()


### PR DESCRIPTION
# What does this PR do?
Only use Bash if it exist, otherwize use sh.

# Motivation
https://github.com/jeessy2/ddns-go/issues/651#issuecomment-1489878461
> 安卓设备中没有bash，无法执行命令获取地址，能否直接运行命令

# Additional Notes
- https://gist.github.com/miguelmota/ed4ec562b8cd1781e7b20151b37de8a0
- https://pkg.go.dev/os/exec#hdr-Executables_in_the_current_directory