### PR TITLE
feat: checkbox to enable Webhook

### DIFF
--- a/config/webhook.go
+++ b/config/webhook.go
@@ -13,6 +13,7 @@ import (
 
 // Webhook Webhook
 type Webhook struct {
+	WebhookEnable      bool
 	WebhookURL         string
 	WebhookRequestBody string
 }
@@ -33,39 +34,40 @@ const (
 func ExecWebhook(domains *Domains, conf *Config) (v4Status updateStatusType, v6Status updateStatusType) {
 	v4Status = getDomainsStatus(domains.Ipv4Domains)
 	v6Status = getDomainsStatus(domains.Ipv6Domains)
-
-	if conf.WebhookURL != "" && (v4Status != UpdatedNothing || v6Status != UpdatedNothing) {
-		// 成功和失败都要触发webhook
-		method := "GET"
-		postPara := ""
-		contentType := "application/x-www-form-urlencoded"
-		if conf.WebhookRequestBody != "" {
-			method = "POST"
-			postPara = replacePara(domains, conf.WebhookRequestBody, v4Status, v6Status)
-			if json.Valid([]byte(postPara)) {
-				contentType = "application/json"
+	if conf.WebhookEnable {
+		if conf.WebhookURL != "" && (v4Status != UpdatedNothing || v6Status != UpdatedNothing) {
+			// 成功和失败都要触发webhook
+			method := "GET"
+			postPara := ""
+			contentType := "application/x-www-form-urlencoded"
+			if conf.WebhookRequestBody != "" {
+				method = "POST"
+				postPara = replacePara(domains, conf.WebhookRequestBody, v4Status, v6Status)
+				if json.Valid([]byte(postPara)) {
+					contentType = "application/json"
+				}
 			}
-		}
-		requestURL := replacePara(domains, conf.WebhookURL, v4Status, v6Status)
-		u, err := url.Parse(requestURL)
-		if err != nil {
-			log.Println("Webhook配置中的URL不正确")
-			return
-		}
-		req, err := http.NewRequest(method, fmt.Sprintf("%s://%s%s?%s", u.Scheme, u.Host, u.Path, u.Query().Encode()), strings.NewReader(postPara))
-		if err != nil {
-			log.Println("创建Webhook请求异常, Err:", err)
-			return
-		}
-		req.Header.Add("content-type", contentType)
+			requestURL := replacePara(domains, conf.WebhookURL, v4Status, v6Status)
+			u, err := url.Parse(requestURL)
+			if err != nil {
+				log.Println("Webhook配置中的URL不正确")
+				return
+			}
+			req, err := http.NewRequest(method, fmt.Sprintf("%s://%s%s?%s", u.Scheme, u.Host, u.Path, u.Query().Encode()), strings.NewReader(postPara))
+			if err != nil {
+				log.Println("创建Webhook请求异常, Err:", err)
+				return
+			}
+			req.Header.Add("content-type", contentType)
 
-		clt := util.CreateHTTPClient()
-		resp, err := clt.Do(req)
-		body, err := util.GetHTTPResponseOrg(resp, requestURL, err)
-		if err == nil {
-			log.Printf("Webhook调用成功, 返回数据: %q\n", string(body))
-		} else {
-			log.Printf("Webhook调用失败，Err：%s\n", err)
+			clt := util.CreateHTTPClient()
+			resp, err := clt.Do(req)
+			body, err := util.GetHTTPResponseOrg(resp, requestURL, err)
+			if err == nil {
+				log.Printf("Webhook调用成功, 返回数据: %q\n", string(body))
+			} else {
+				log.Printf("Webhook调用失败，Err：%s\n", err)
+			}
 		}
 	}
 	return

--- a/web/save.go
+++ b/web/save.go
@@ -42,6 +42,7 @@ func checkAndSave(request *http.Request) string {
 	conf.NotAllowWanAccess = request.FormValue("NotAllowWanAccess") == "on"
 	conf.Username = strings.TrimSpace(request.FormValue("Username"))
 	conf.Password = request.FormValue("Password")
+	conf.WebhookEnable = request.FormValue("WebhookEnable") == "on"
 	conf.WebhookURL = strings.TrimSpace(request.FormValue("WebhookURL"))
 	conf.WebhookRequestBody = strings.TrimSpace(request.FormValue("WebhookRequestBody"))
 	// 如启用公网访问，帐号密码不能为空

--- a/web/webhookTest.go
+++ b/web/webhookTest.go
@@ -28,6 +28,7 @@ func WebhookTest(writer http.ResponseWriter, request *http.Request) {
 
 	fakeConfig := &config.Config{
 		Webhook: config.Webhook{
+			WebhookEnable:      true,
 			WebhookURL:         url,
 			WebhookRequestBody: requestBody,
 		},

--- a/web/writing.go
+++ b/web/writing.go
@@ -21,6 +21,7 @@ type writtingData struct {
 	DnsConf           template.JS
 	NotAllowWanAccess string
 	config.User
+	WebhookEnable string
 	config.Webhook
 	Version string
 }
@@ -66,6 +67,7 @@ func Writing(writer http.ResponseWriter, request *http.Request) {
 		DnsConf:           template.JS(getDnsConfStr(conf.DnsConf)),
 		NotAllowWanAccess: BooltoOn(conf.NotAllowWanAccess),
 		User:              conf.User,
+		WebhookEnable:     BooltoOn(conf.WebhookEnable),
 		Webhook:           conf.Webhook,
 		Version:           os.Getenv(VersionEnv),
 	})

--- a/web/writing.html
+++ b/web/writing.html
@@ -328,6 +328,14 @@
             <div class="portlet__body">
 
               <div class="form-group row">
+                <label for="WebhookEnable" class="col-sm-2">是否启用</label>
+                <div class="col-sm-10">
+                  <input type="checkbox" class="form-check-inline" style="margin-top: 5px;" id="WebhookEnable"
+                    name="WebhookEnable" checked>
+                </div>
+              </div>
+
+              <div class="form-group row">
                 <label for="WebhookURL" class="col-sm-2 col-form-label">URL</label>
                 <div class="col-sm-10">
                   <input class="form-control form" name="WebhookURL" id="WebhookURL" value=""
@@ -445,6 +453,7 @@
       document.getElementById('NotAllowWanAccess').checked = "{{.NotAllowWanAccess}}"=='on';
       document.getElementById('Username').value = "{{.Username}}";
       document.getElementById('Password').value = "{{.Password}}";
+      document.getElementById('WebhookEnable').checked = "{{.WebhookEnable}}"=='on';
       document.getElementById('WebhookURL').value = "{{.WebhookURL}}";
       document.getElementById('WebhookRequestBody').value = "{{.WebhookRequestBody}}";
     });


### PR DESCRIPTION
# What does this PR do?
Add a checkbox for enabling Webhook.

Closes #655.

# Motivation
#655

# Additional Notes
[`FormData.append()`](https://developer.mozilla.org/docs/Web/API/FormData/append) only accepts string. But it can be [parsed as JSON](https://stackoverflow.com/questions/33625248/formdata-sends-boolean-as-string-to-server) on the backend.