### PR TITLE
feat: HTTP Proxy

### DIFF
--- a/main.go
+++ b/main.go
@@ -38,6 +38,9 @@ var noWebService = flag.Bool("noweb", false, "不启动 web 服务")
 // 跳过验证证书
 var skipVerify = flag.Bool("skipVerify", false, "跳过验证证书, 适合不能升级的老系统")
 
+// HTTP 代理
+var HTTPProxy = flag.String("proxy", "", "HTTP 代理")
+
 //go:embed static
 var staticEmbededFiles embed.FS
 
@@ -59,6 +62,9 @@ func main() {
 	}
 	if *skipVerify {
 		os.Setenv(util.SkipVerifyENV, "true")
+	}
+	if *HTTPProxy != "" {
+		os.Setenv(util.HTTPProxyEnv, *HTTPProxy)
 	}
 	switch *serviceType {
 	case "install":

--- a/main.go
+++ b/main.go
@@ -38,9 +38,6 @@ var noWebService = flag.Bool("noweb", false, "不启动 web 服务")
 // 跳过验证证书
 var skipVerify = flag.Bool("skipVerify", false, "跳过验证证书, 适合不能升级的老系统")
 
-// HTTP 代理
-var HTTPProxy = flag.String("proxy", "", "HTTP 代理")
-
 //go:embed static
 var staticEmbededFiles embed.FS
 
@@ -62,9 +59,6 @@ func main() {
 	}
 	if *skipVerify {
 		os.Setenv(util.SkipVerifyENV, "true")
-	}
-	if *HTTPProxy != "" {
-		os.Setenv(util.HTTPProxyEnv, *HTTPProxy)
 	}
 	switch *serviceType {
 	case "install":

--- a/util/http_client_util.go
+++ b/util/http_client_util.go
@@ -18,7 +18,6 @@ var dialer = &net.Dialer{
 
 var defaultTransport = &http.Transport{
 	// from http.DefaultTransport
-	Proxy: http.ProxyFromEnvironment,
 	DialContext: func(ctx context.Context, network, address string) (net.Conn, error) {
 		return dialer.DialContext(ctx, network, address)
 	},
@@ -31,6 +30,7 @@ var defaultTransport = &http.Transport{
 
 // CreateHTTPClient Create Default HTTP Client
 func CreateHTTPClient() *http.Client {
+	defaultTransport.Proxy = getHTTPProxy()
 	// SkipVerfiry
 	defaultTransport.TLSClientConfig = &tls.Config{InsecureSkipVerify: os.Getenv(SkipVerifyENV) == "true"}
 	return &http.Client{

--- a/util/proxy.go
+++ b/util/proxy.go
@@ -7,18 +7,20 @@ import (
 	"os"
 )
 
-const HTTPProxyEnv = "DDNS_GO_HTTP_PROXY"
+var proxyEnvs = []string{"HTTP_PROXY", "HTTPS_PROXY", "http_proxy", "https_proxy"}
 
-// getHTTPProxy 获取 HTTPProxyEnv 的值。如果值为 URL 则使用值的 HTTP 代理，否则使用变量的 HTTP 代理。
+// getHTTPProxy 获取 HTTP 代理变量的值。如果值为 URL 则使用值，否则使用 ProxyFromEnvironment。
 func getHTTPProxy() func(*http.Request) (*url.URL, error) {
-	proxy := os.Getenv(HTTPProxyEnv)
-	if proxy != "" {
-		proxyURL, err := url.Parse(proxy)
-		if err != nil {
-			log.Println("解析 HTTP 代理失败：", err)
-			return http.ProxyFromEnvironment
+	for _, key := range proxyEnvs {
+		proxy := os.Getenv(key)
+		if proxy != "" {
+			proxyURL, err := url.Parse(proxy)
+			if err != nil {
+				log.Println("解析 HTTP 代理失败：", err)
+				return http.ProxyFromEnvironment
+			}
+			return http.ProxyURL(proxyURL)
 		}
-		return http.ProxyURL(proxyURL)
 	}
 	return http.ProxyFromEnvironment
 }

--- a/util/proxy.go
+++ b/util/proxy.go
@@ -1,0 +1,24 @@
+package util
+
+import (
+	"log"
+	"net/http"
+	"net/url"
+	"os"
+)
+
+const HTTPProxyEnv = "DDNS_GO_HTTP_PROXY"
+
+// getHTTPProxy 获取 HTTPProxyEnv 的值。如果值为 URL 则使用值的 HTTP 代理，否则使用变量的 HTTP 代理。
+func getHTTPProxy() func(*http.Request) (*url.URL, error) {
+	proxy := os.Getenv(HTTPProxyEnv)
+	if proxy != "" {
+		proxyURL, err := url.Parse(proxy)
+		if err != nil {
+			log.Println("解析 HTTP 代理失败：", err)
+			return http.ProxyFromEnvironment
+		}
+		return http.ProxyURL(proxyURL)
+	}
+	return http.ProxyFromEnvironment
+}


### PR DESCRIPTION
# What does this PR do?
Add the flag `proxy` and use `http.ProxyURL` when it exists.
Fixes #665.

# Motivation
#665 metioned that the current HTTP Proxy `http.ProxyFromEnvironment` doesn't seem to work when adding a proxy environment.

# Additional Notes
- [Setting up proxy for HTTP client - Stack Overflow](https://stackoverflow.com/questions/14661511/setting-up-proxy-for-http-client)
- [http package - net/http - Go Packages](https://pkg.go.dev/net/http#ProxyURL)