### PR TITLE
ci: success in forked repository

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -10,6 +10,7 @@ on:
  
 jobs:
   buildx-dockerhub:
+    if: github.repository == 'jeessy2/ddns-go'
     runs-on: ubuntu-latest
     env:
       DOCKER_REPO: ${{ secrets.DOCKER_USERNAME }}/ddns-go

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,9 @@ on:
     tags:
     - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
 
+permissions:
+  contents: write
+
 jobs:
   goreleaser:
     name: Build


### PR DESCRIPTION
# What does this PR do?
Make all workflows success in forked repository.

# Motivation
There're two workflows in forked repository that will fail: `docker-image.yml` and `release.yml`.

`docker-image.yml` fails because the secrets it needs does not exist in forked repository. Running it only in the `jeessy2/ddns-go` repository to fix this.

`release.yml` fails because the default `GITHUB_TOKEN` permission is now read-only. Add `contents: write` to fix this.

# Additional Notes
- https://docs.github.com/actions/using-workflows/workflow-syntax-for-github-actions#example-only-run-job-for-specific-repository
- https://github.blog/changelog/2023-02-02-github-actions-updating-the-default-github_token-permissions-to-read-only/
- https://github.com/goreleaser/goreleaser-action#environment-variables