### PR TITLE
feat: custom DNS server

### DIFF
--- a/main.go
+++ b/main.go
@@ -38,6 +38,9 @@ var noWebService = flag.Bool("noweb", false, "不启动 web 服务")
 // 跳过验证证书
 var skipVerify = flag.Bool("skipVerify", false, "跳过验证证书, 适合不能升级的老系统")
 
+// 自定义 DNS 服务器
+var customDNSServer = flag.String("dns", "", "自定义 DNS 服务器（例如 1.1.1.1）")
+
 //go:embed static
 var staticEmbededFiles embed.FS
 
@@ -46,9 +49,6 @@ var faviconEmbededFile embed.FS
 
 // version
 var version = "DEV"
-
-// buildTime
-var buildTime = ""
 
 func main() {
 	flag.Parse()
@@ -62,6 +62,9 @@ func main() {
 	}
 	if *skipVerify {
 		os.Setenv(util.SkipVerifyENV, "true")
+	}
+	if *customDNSServer != "" {
+		os.Setenv(util.DNSServerEnv, *customDNSServer+":53")
 	}
 	switch *serviceType {
 	case "install":

--- a/util/dns.go
+++ b/util/dns.go
@@ -1,5 +1,3 @@
-// based on https://github.com/v2fly/v2ray-core/blob/0c5abc7e53aed41480dd2a07f611bd34c753e880/transport/internet/system_dns_android.go
-
 package util
 
 import (

--- a/util/dns.go
+++ b/util/dns.go
@@ -1,0 +1,25 @@
+// based on https://github.com/v2fly/v2ray-core/blob/0c5abc7e53aed41480dd2a07f611bd34c753e880/transport/internet/system_dns_android.go
+
+package util
+
+import (
+	"context"
+	"net"
+	"os"
+)
+
+const DNSServerEnv = "DDNS_GO_DNS_SERVER"
+
+// customDNSResolver 当 DNSServerEnv 值不为空时，使用 Go 内置 DNS 解析器来解析其 DNS 服务器。
+func customDNSResolver() *net.Resolver {
+	s := os.Getenv(DNSServerEnv)
+	if s != "" {
+		return &net.Resolver{
+			PreferGo: true,
+			Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
+				return net.Dial("udp", s)
+			},
+		}
+	}
+	return &net.Resolver{}
+}

--- a/util/dns_test.go
+++ b/util/dns_test.go
@@ -1,5 +1,3 @@
-// based on https://github.com/v2fly/v2ray-core/blob/0c5abc7e53aed41480dd2a07f611bd34c753e880/transport/internet/system_dns_android_test.go
-
 package util
 
 import (
@@ -10,8 +8,8 @@ import (
 
 // TestCustomDNSResolver 测试能否通过 DNSServerEnv 值的 DNS 服务器解析域名的 IP。
 func TestCustomDNSResolver(t *testing.T) {
-	os.Setenv(DNSServerEnv, "223.5.5.5:53")
-	_, err := customDNSResolver().LookupIP(context.Background(), "ip", "aliyun.com")
+	os.Setenv(DNSServerEnv, "1.1.1.1:53")
+	_, err := customDNSResolver().LookupIP(context.Background(), "ip", "cloudflare.com")
 	if err != nil {
 		t.Errorf("Failed to lookup IP, err: %v", err)
 	}

--- a/util/dns_test.go
+++ b/util/dns_test.go
@@ -1,0 +1,18 @@
+// based on https://github.com/v2fly/v2ray-core/blob/0c5abc7e53aed41480dd2a07f611bd34c753e880/transport/internet/system_dns_android_test.go
+
+package util
+
+import (
+	"context"
+	"os"
+	"testing"
+)
+
+// TestCustomDNSResolver 测试能否通过 DNSServerEnv 值的 DNS 服务器解析域名的 IP。
+func TestCustomDNSResolver(t *testing.T) {
+	os.Setenv(DNSServerEnv, "223.5.5.5:53")
+	_, err := customDNSResolver().LookupIP(context.Background(), "ip", "aliyun.com")
+	if err != nil {
+		t.Errorf("Failed to lookup IP, err: %v", err)
+	}
+}

--- a/util/http_client_util.go
+++ b/util/http_client_util.go
@@ -31,6 +31,7 @@ var defaultTransport = &http.Transport{
 
 // CreateHTTPClient Create Default HTTP Client
 func CreateHTTPClient() *http.Client {
+	dialer.Resolver = customDNSResolver()
 	// SkipVerfiry
 	defaultTransport.TLSClientConfig = &tls.Config{InsecureSkipVerify: os.Getenv(SkipVerifyENV) == "true"}
 	return &http.Client{
@@ -73,6 +74,7 @@ var noProxyTcp6Transport = &http.Transport{
 
 // CreateNoProxyHTTPClient Create NoProxy HTTP Client
 func CreateNoProxyHTTPClient(network string) *http.Client {
+	dialer.Resolver = customDNSResolver()
 	if network == "tcp6" {
 		// SkipVerfiry
 		noProxyTcp6Transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: os.Getenv(SkipVerifyENV) == "true"}


### PR DESCRIPTION
# What does this PR do?
Support for custom DNS server.

- Fix #587 and fix #589.
- Continue with #590.

# Motivation
If the file `/etc/resolv.conf` does not exist for Unix, Go will use `127.0.0.1` or `::1` as the DNS server. Support for custom DNS server to resolve the issue.

# Additional Notes
- fatedier/frp#700
- golang/go#8877
- v2ray/v2ray-core#1909
- v2fly/v2ray-core#966
- https://gist.github.com/Integralist/8a9cb8924f75ae42487fd877b03360e2
- https://pkg.go.dev/net#Resolver

**The solution may not be good enough, sorry.**