### PR TITLE
feat: 增加睡眠免打扰模式，开启后不会去频繁请求获取ip及更新dns服务商配置

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -60,6 +60,7 @@ type Config struct {
 	Webhook
 	// 禁止公网访问
 	NotAllowWanAccess bool
+	SleepMode
 }
 
 // ConfigCache ConfigCache

--- a/config/sleep.go
+++ b/config/sleep.go
@@ -1,0 +1,8 @@
+package config
+
+// SleepMode 睡眠模式
+type SleepMode struct {
+	SleepDisable   bool
+	SleepTimeStart string
+	SleepTimeEnd   string
+}

--- a/dns/index.go
+++ b/dns/index.go
@@ -33,6 +33,11 @@ func RunOnce() {
 	if err != nil {
 		return
 	}
+	// 校验是否睡眠模式
+	if conf.SleepMode.SleepDisable && util.IsSleepMode(conf.SleepMode.SleepTimeStart, conf.SleepMode.SleepTimeEnd) {
+		log.Printf("当前处于睡眠状态")
+		return
+	}
 	if util.ForceCompareGlobal || len(Ipcache) != len(conf.DnsConf) {
 		Ipcache = [][2]util.IpCache{}
 		for range conf.DnsConf {

--- a/util/sleep_util.go
+++ b/util/sleep_util.go
@@ -1,0 +1,33 @@
+package util
+
+import (
+	"fmt"
+	"log"
+	"time"
+)
+
+func IsSleepMode(sleepTimeStart string, sleepTimeEnd string) bool {
+	var cstZone = time.FixedZone("CST", 8*60*60)
+	now := time.Now().In(cstZone)
+	currentDate := now.Format("2006-01-02")
+
+	start, err1 := time.ParseInLocation("2006-01-02 15:04", currentDate+" "+sleepTimeStart, cstZone)
+	if err1 != nil {
+		log.Printf("睡眠状态判断异常, ERR: %s\n", err1)
+		fmt.Println("err:", err1)
+		return false
+	}
+	end, err2 := time.ParseInLocation("2006-01-02 15:04", currentDate+" "+sleepTimeEnd, cstZone)
+	if err2 != nil {
+		log.Printf("睡眠状态判断异常, ERR: %s\n", err2)
+		fmt.Println("err:", err2)
+		return false
+	}
+	if start.After(end) {
+		end = end.Add(24 * time.Hour)
+	}
+	if now.After(start) && now.Before(end) {
+		return true
+	}
+	return false
+}

--- a/util/sleep_util_test.go
+++ b/util/sleep_util_test.go
@@ -1,0 +1,12 @@
+package util
+
+import (
+	"testing"
+)
+
+func TestIsSleepMode(t *testing.T) {
+	start := "22:00"
+	end := "08:00"
+	sleepMode := IsSleepMode(start, end)
+	t.Log("睡眠模式:", sleepMode)
+}

--- a/web/save.go
+++ b/web/save.go
@@ -45,6 +45,9 @@ func checkAndSave(request *http.Request) string {
 	conf.WebhookDisable = request.FormValue("WebhookDisable") == "on"
 	conf.WebhookURL = strings.TrimSpace(request.FormValue("WebhookURL"))
 	conf.WebhookRequestBody = strings.TrimSpace(request.FormValue("WebhookRequestBody"))
+	conf.SleepDisable = request.FormValue("SleepDisable") == "on"
+	conf.SleepTimeStart = strings.TrimSpace(request.FormValue("SleepTimeStart"))
+	conf.SleepTimeEnd = strings.TrimSpace(request.FormValue("SleepTimeEnd"))
 	// 如启用公网访问，帐号密码不能为空
 	if !conf.NotAllowWanAccess && (conf.Username == "" || conf.Password == "") {
 		return "启用外网访问, 必须输入登录用户名/密码"

--- a/web/writing.go
+++ b/web/writing.go
@@ -23,6 +23,8 @@ type writtingData struct {
 	config.User
 	WebhookDisable string
 	config.Webhook
+	SleepDisable string
+	config.SleepMode
 	Version string
 }
 
@@ -69,6 +71,8 @@ func Writing(writer http.ResponseWriter, request *http.Request) {
 		User:              conf.User,
 		WebhookDisable:    BooltoOn(conf.WebhookDisable),
 		Webhook:           conf.Webhook,
+		SleepDisable:      BooltoOn(conf.SleepDisable),
+		SleepMode:         conf.SleepMode,
 		Version:           os.Getenv(VersionEnv),
 	})
 }

--- a/web/writing.html
+++ b/web/writing.html
@@ -308,6 +308,38 @@
 
             </div>
           </div>
+          <div class="portlet">
+            <h5 class="portlet__head">睡眠设置</h5>
+            <div class="portlet__body">
+
+              <div class="form-group row">
+                <label for="SleepDisable" class="col-sm-2">是否开启</label>
+                <div class="col-sm-10">
+                  <input type="checkbox" class="form-check-inline" style="margin-top: 5px;" id="SleepDisable"
+                    name="SleepDisable" checked>
+                </div>
+              </div>
+
+              <div class="form-group row">
+                <label for="SleepTimeStart" class="col-sm-2 col-form-label">睡眠时间</label>
+                <div class="col-sm-10">
+                  <div>
+                  <input type="time" name="SleepTimeStart" id="SleepTimeStart" value="" aria-describedby="SleepTimeStart_help">
+                  ~
+                  <input type="time" name="SleepTimeEnd" id="SleepTimeEnd" value="" aria-describedby="SleepTimeStart_help">
+                  </div>
+                  <small id="SleepTimeStart_help" class="form-text text-muted">
+                    当前时间在设置时间段内时, 程序进入睡眠模式, 不会去执行解析dns操作
+                  </small>
+                </div>
+                <div class="col-sm-2">
+
+                </div>
+              </div>
+
+
+            </div>
+          </div>
         </form>
 
         <button class="btn btn-primary submit_btn" style="margin-bottom: 16px;">Save</button>
@@ -481,6 +513,9 @@
       document.getElementById('WebhookDisable').checked = "{{.WebhookDisable}}" == 'on';
       document.getElementById('WebhookURL').value = "{{.WebhookURL}}";
       document.getElementById('WebhookRequestBody').value = "{{.WebhookRequestBody}}";
+      document.getElementById('SleepDisable').checked = "{{.SleepDisable}}" == 'on';
+      document.getElementById('SleepTimeStart').value = "{{.SleepTimeStart}}";
+      document.getElementById('SleepTimeEnd').value = "{{.SleepTimeEnd}}";
     });
 
     let beforeDnsID = "";


### PR DESCRIPTION
# What does this PR do?
增加睡眠免打扰模式

# Motivation
增加睡眠免打扰模式
场景：路由设置有定时关机或休眠断网模式，此时ddns-go不需要去频繁获取外网ip，也不需要webhook告警
# Additional Notes
