### PR TITLE
docs(namecheap): IPv6 is not supported

### DIFF
--- a/dns/namecheap.go
+++ b/dns/namecheap.go
@@ -60,10 +60,13 @@ func (nc *NameCheap) addUpdateDomainRecords(recordType string) {
 			return
 		}
 	} else {
-		if nc.lastIpv6 == ipAddr {
-			log.Println("你的IPv6未变化, 未触发Namecheap请求")
-			return
-		}
+		// https://www.namecheap.com/support/knowledgebase/article.aspx/29/11/how-to-dynamically-update-the-hosts-ip-with-an-http-request/
+		log.Println("NameCheap DDNS 不支持更新 IPv6！")
+		return
+		// if nc.lastIpv6 == ipAddr {
+		// 	log.Println("你的IPv6未变化, 未触发Namecheap请求")
+		// 	return
+		// }
 	}
 
 	for _, domain := range domains {

--- a/dns/namecheap.go
+++ b/dns/namecheap.go
@@ -61,7 +61,7 @@ func (nc *NameCheap) addUpdateDomainRecords(recordType string) {
 		}
 	} else {
 		// https://www.namecheap.com/support/knowledgebase/article.aspx/29/11/how-to-dynamically-update-the-hosts-ip-with-an-http-request/
-		log.Println("NameCheap DDNS 不支持更新 IPv6！")
+		log.Println("Namecheap DDNS 不支持更新 IPv6！")
 		return
 		// if nc.lastIpv6 == ipAddr {
 		// 	log.Println("你的IPv6未变化, 未触发Namecheap请求")


### PR DESCRIPTION
# What does this PR do?
IPv6 is not supported by Namecheap Dynamic DNS, so the `addUpdateDomainRecords` func will end when `recordType` is AAAA.

# Motivation
#686

# Additional Notes
Ref: https://www.namecheap.com/support/knowledgebase/article.aspx/29/11/how-to-dynamically-update-the-hosts-ip-with-an-http-request/

> **NOTE**: It is only possible to dynamically update IPv4 addresses (A records) at this time. Currently, IPv6 is not supported by our Dynamic DNS.