### PR TITLE
fix(webhook): RequestBody must be valid JSON

### DIFF
--- a/config/webhook.go
+++ b/config/webhook.go
@@ -45,6 +45,9 @@ func ExecWebhook(domains *Domains, conf *Config) (v4Status updateStatusType, v6S
 			postPara = replacePara(domains, conf.WebhookRequestBody, v4Status, v6Status)
 			if json.Valid([]byte(postPara)) {
 				contentType = "application/json"
+			} else {
+				log.Println("RequestBody 的 JSON 无效！")
+				return
 			}
 		}
 		requestURL := replacePara(domains, conf.WebhookURL, v4Status, v6Status)


### PR DESCRIPTION
# What does this PR do?
Make `RequestBody` must be a valid JSON.

# Motivation
There is no indication when JSON is invalid.

#673 #704

# Additional Notes
