### PR TITLE
feat: ip cache time configable

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,9 @@
 - [可选] 服务卸载
   - Mac/Linux: `sudo ./ddns-go -s uninstall`
   - Win(以管理员打开cmd): `.\ddns-go.exe -s uninstall`
-- [可选] 支持安装或启动时带参数 `-l`监听地址 `-f`同步间隔时间(秒) `-c`自定义配置文件路径 `-noweb`不启动web服务 `-skipVerify`跳过证书验证。如：`./ddns-go -s install -l :9877 -f 600 -c /Users/name/ddns-go.yaml`
+- [可选] 支持安装或启动时带参数 `-l`监听地址 `-f`同步间隔时间(秒) `-cacheTimes`间隔N次与服务商比对 `-c`自定义配置文件路径 `-noweb`不启动web服务 `-skipVerify`跳过证书验证。如：`./ddns-go -s install -l :9877 -f 600 -c /Users/name/ddns-go.yaml`
+
+> **Note** 通过合理的配置 `-f` 和 `-cacheTimes` 可以实现 IP 变化即时触发更新且不会被 DDNS 服务商限流, 例如 `-f 10 -cacheTimes 360` 效果为每 10 秒检查一次本地 IP 变化, 每小时去公网对比一下 IP 变化
 
 ## Docker中使用
 
@@ -179,7 +181,7 @@
 
   - Discord任意客户端 -> 伺服器 -> 频道设置 -> 整合 -> 查看Webhook -> 新Webhook -> 复制Webhook网址
   - URL中输入Discord复制的 `Webhook网址`
-  - RequestBody中输入 
+  - RequestBody中输入
     ```json
     {
         "content": "域名 #{ipv4Domains} 动态解析 #{ipv4Result}.",

--- a/main.go
+++ b/main.go
@@ -26,6 +26,9 @@ var listen = flag.String("l", ":9876", "监听地址")
 // 更新频率(秒)
 var every = flag.Int("f", 300, "同步间隔时间(秒)")
 
+// 缓存次数
+var ipCacheTimes = flag.Int("cacheTimes", 6, "间隔N次与服务商比对")
+
 // 服务管理
 var serviceType = flag.String("s", "", "服务管理, 支持install, uninstall")
 
@@ -66,6 +69,7 @@ func main() {
 	if *customDNSServer != "" {
 		os.Setenv(util.DNSServerEnv, *customDNSServer+":53")
 	}
+	os.Setenv(util.IPCacheTimesENV, strconv.Itoa(*ipCacheTimes))
 	switch *serviceType {
 	case "install":
 		installService()

--- a/util/ip_cache.go
+++ b/util/ip_cache.go
@@ -1,5 +1,12 @@
 package util
 
+import (
+	"os"
+	"strconv"
+)
+
+const IPCacheTimesENV = "DDNS_IP_CACHE_TIMES"
+
 // IpCache 上次IP缓存
 type IpCache struct {
 	Addr          string // 缓存地址
@@ -15,8 +22,12 @@ func (d *IpCache) Check(newAddr string) bool {
 	}
 	// 地址改变 或 达到剩余次数
 	if d.Addr != newAddr || d.Times <= 1 {
+		IPCacheTimes, err := strconv.Atoi(os.Getenv(IPCacheTimesENV))
+		if err != nil {
+			IPCacheTimes = 6
+		}
 		d.Addr = newAddr
-		d.Times = 6
+		d.Times = IPCacheTimes
 		return true
 	}
 	d.Addr = newAddr


### PR DESCRIPTION
# What does this PR do?
https://github.com/jeessy2/ddns-go/issues/706
# Motivation
可配置 IP 缓存次数,增加本地IP 检查频率, 且不会被服务商限流
# Additional Notes
