### PR TITLE
fix(open_explorer): don't execute command on Termux

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        goarch: [amd64, arm64]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -17,10 +20,15 @@ jobs:
           go-version-file: 'go.mod'
 
       - name: Test
-        run: make build test
-
+        run: |
+          # Run tests only when GOARCH is amd64, otherwize run builds only.
+          if [ "${{ matrix.goarch }}" = "amd64" ]; then
+            make build test
+          else
+            GOARCH=${{ matrix.goarch }} make build
+          fi
       - name: Upload artifact
         uses: actions/upload-artifact@v3
         with:
-          name: ddns-go
+          name: ddns-go_${{ matrix.goarch }}
           path: ddns-go

--- a/util/open_explorer.go
+++ b/util/open_explorer.go
@@ -15,6 +15,12 @@ func OpenExplorer(url string) {
 	case "darwin": // macOS
 		cmd = exec.Command("open", url)
 	default: // Linux
+		// 如果在 Termux 中运行则停止，因为 exec.Command 可能会触发 SIGSYS: bad system call
+		// https://github.com/docker/compose/issues/10511#issuecomment-1531453435
+		if isTermux() {
+			return
+		}
+
 		cmd = exec.Command("xdg-open", url)
 	}
 

--- a/util/termux.go
+++ b/util/termux.go
@@ -1,0 +1,10 @@
+package util
+
+import "os"
+
+// isTermux 是否在 Termux 中运行
+//
+// https://wiki.termux.com/wiki/Getting_started
+func isTermux() bool {
+	return os.Getenv("PREFIX") == "/data/data/com.termux/files/usr"
+}

--- a/util/termux_test.go
+++ b/util/termux_test.go
@@ -1,0 +1,23 @@
+package util
+
+import (
+	"os"
+	"testing"
+)
+
+// TestIsTermux 测试在或不在 Termux 中运行都能正确判断
+func TestIsTermux(t *testing.T) {
+	// 模拟在 Termux 中运行
+	os.Setenv("PREFIX", "/data/data/com.termux/files/usr")
+
+	if !isTermux() {
+		t.Error("期待 isTermux 返回 true，但得到 false。")
+	}
+
+	// 清除 PREFIX 变量，模拟不在 Termux 中运行
+	os.Unsetenv("PREFIX")
+
+	if isTermux() {
+		t.Error("期待 isTermux 返回 false，但得到 true。")
+	}
+}


### PR DESCRIPTION
# What does this PR do?
Don't execute command on Termux, as Android has a seccomp policy blocking `faccessat2`.

Can be imperfectly fixes #672.

Also build arm64 in the `test` CI.

# Motivation
- #672
- #674

# Additional Notes
- https://github.com/golang/go/commit/58f6022eee95f43b4e0dc640b012bb3f574898f1
- golang/go#60125
- JanDeDobbeleer/oh-my-posh#3560
- docker/compose#10511