### PR TITLE
fix: add `-v` flag to output version

### DIFF
--- a/main.go
+++ b/main.go
@@ -20,6 +20,10 @@ import (
 	"github.com/kardianos/service"
 )
 
+// ddns-go 版本
+// ddns-go version
+var versionFlag = flag.Bool("v", false, "ddns-go 版本")
+
 // 监听地址
 var listen = flag.String("l", ":9876", "监听地址")
 
@@ -55,6 +59,10 @@ var version = "DEV"
 
 func main() {
 	flag.Parse()
+	if *versionFlag {
+		fmt.Println(version)
+		return
+	}
 	if _, err := net.ResolveTCPAddr("tcp", *listen); err != nil {
 		log.Fatalf("解析监听地址异常，%s", err)
 	}


### PR DESCRIPTION
# What does this PR do?
Add the `-v` flag to output the `ddns-go` version.

# Motivation
Related to Homebrew/homebrew-core#132725.

# Additional Notes
