### PR TITLE
feat: no more delay on first run

### DIFF
--- a/dns/index.go
+++ b/dns/index.go
@@ -1,7 +1,6 @@
 package dns
 
 import (
-	"log"
 	"time"
 
 	"github.com/jeessy2/ddns-go/v5/config"
@@ -18,9 +17,7 @@ type DNS interface {
 var Ipcache = [][2]util.IpCache{}
 
 // RunTimer 定时运行
-func RunTimer(firstDelay time.Duration, delay time.Duration) {
-	log.Printf("第一次运行将等待 %d 秒后运行 (等待网络)", int(firstDelay.Seconds()))
-	time.Sleep(firstDelay)
+func RunTimer(delay time.Duration) {
 	for {
 		RunOnce()
 		time.Sleep(delay)

--- a/dns/index.go
+++ b/dns/index.go
@@ -18,6 +18,8 @@ var Ipcache = [][2]util.IpCache{}
 
 // RunTimer 定时运行
 func RunTimer(delay time.Duration) {
+	waitForNetworkConnected()
+
 	for {
 		RunOnce()
 		time.Sleep(delay)

--- a/dns/wait_net.go
+++ b/dns/wait_net.go
@@ -1,0 +1,42 @@
+package dns
+
+import (
+	"log"
+	"net/http"
+	"time"
+)
+
+// waitForNetworkConnected 等待网络连接后继续
+func waitForNetworkConnected() {
+	// 延时 5 秒
+	timeout := time.Second * 5
+
+	// 测试网络是否连接的域名
+	addresses := []string{
+		alidnsEndpoint,
+		baiduEndpoint,
+		zonesAPI,
+		recordListAPI,
+		googleDomainEndpoint,
+		huaweicloudEndpoint,
+		nameCheapEndpoint,
+		porkbunEndpoint,
+		tencentCloudEndPoint,
+	}
+
+	for {
+		for _, addr := range addresses {
+			resp, err := http.Get(addr)
+			if err != nil {
+				log.Printf("等待网络连接：%s。%s 后重试...", err, timeout)
+				// 等待 5 秒后重试
+				time.Sleep(timeout)
+				continue
+			}
+
+			// 网络已连接
+			resp.Body.Close()
+			return
+		}
+	}
+}

--- a/main.go
+++ b/main.go
@@ -125,9 +125,6 @@ func run() {
 		}()
 	}
 
-	// 等待网络连接后继续
-	util.WaitForNetworkConnected()
-
 	// 定时运行
 	dns.RunTimer(time.Duration(*every) * time.Second)
 }

--- a/main.go
+++ b/main.go
@@ -171,7 +171,6 @@ func (p *program) Start(s service.Service) error {
 	return nil
 }
 func (p *program) run() {
-	// 服务运行，延时20秒运行，等待网络
 	run()
 }
 func (p *program) Stop(s service.Service) error {

--- a/main.go
+++ b/main.go
@@ -85,7 +85,7 @@ func main() {
 		uninstallService()
 	default:
 		if util.IsRunInDocker() {
-			run(10 * time.Second)
+			run()
 		} else {
 			s := getService()
 			status, _ := s.Status()
@@ -100,13 +100,13 @@ func main() {
 				default:
 					log.Println("可使用 sudo ./ddns-go -s install 安装服务运行")
 				}
-				run(20 * time.Second)
+				run()
 			}
 		}
 	}
 }
 
-func run(firstDelay time.Duration) {
+func run() {
 	// 第一次运行判断是否已设置过帐号密码
 	conf, err := config.GetConfigCached()
 	conf.CompatibleConfig()
@@ -126,7 +126,7 @@ func run(firstDelay time.Duration) {
 	}
 
 	// 定时运行
-	dns.RunTimer(firstDelay, time.Duration(*every)*time.Second)
+	dns.RunTimer(time.Duration(*every) * time.Second)
 }
 
 func staticFsFunc(writer http.ResponseWriter, request *http.Request) {
@@ -172,7 +172,7 @@ func (p *program) Start(s service.Service) error {
 }
 func (p *program) run() {
 	// 服务运行，延时20秒运行，等待网络
-	run(20 * time.Second)
+	run()
 }
 func (p *program) Stop(s service.Service) error {
 	// Stop should not block. Return with a few seconds.
@@ -181,16 +181,28 @@ func (p *program) Stop(s service.Service) error {
 
 func getService() service.Service {
 	options := make(service.KeyValue)
-	if service.ChosenSystem().String() == "unix-systemv" {
+	var depends []string
+
+	// 确保服务等待网络就绪后再启动
+	switch service.ChosenSystem().String() {
+	case "unix-systemv":
 		options["SysvScript"] = sysvScript
+	case "windows-service":
+		// 将 Windows 服务的启动类型设为自动(延迟启动)
+		options["DelayedAutoStart"] = true
+	default:
+		// 向 Systemd 添加网络依赖
+		depends = append(depends, "Requires=network.target",
+			"After=network-online.target")
 	}
 
 	svcConfig := &service.Config{
-		Name:        "ddns-go",
-		DisplayName: "ddns-go",
-		Description: "简单好用的DDNS。自动更新域名解析到公网IP(支持阿里云、腾讯云dnspod、Cloudflare、Callback、华为云、百度云、Porkbun、GoDaddy、Google Domain)",
-		Arguments:   []string{"-l", *listen, "-f", strconv.Itoa(*every), "-c", *configFilePath},
-		Option:      options,
+		Name:         "ddns-go",
+		DisplayName:  "ddns-go",
+		Description:  "简单好用的DDNS。自动更新域名解析到公网IP(支持阿里云、腾讯云dnspod、Cloudflare、Callback、华为云、百度云、Porkbun、GoDaddy、Google Domain)",
+		Arguments:    []string{"-l", *listen, "-f", strconv.Itoa(*every), "-c", *configFilePath},
+		Dependencies: depends,
+		Option:       options,
 	}
 
 	if *noWebService {

--- a/main.go
+++ b/main.go
@@ -125,6 +125,9 @@ func run() {
 		}()
 	}
 
+	// 等待网络连接后继续
+	util.WaitForNetworkConnected()
+
 	// 定时运行
 	dns.RunTimer(time.Duration(*every) * time.Second)
 }

--- a/util/net.go
+++ b/util/net.go
@@ -1,9 +1,11 @@
 package util
 
 import (
+	"log"
 	"net"
 	"net/http"
 	"strings"
+	"time"
 )
 
 // IsPrivateNetwork 是否为私有地址
@@ -46,4 +48,24 @@ func GetRequestIPStr(r *http.Request) (addr string) {
 		addr = addr + " ,Forwarded-For: " + r.Header.Get("X-Forwarded-For")
 	}
 	return addr
+}
+
+// WaitForNetworkConnected 等待网络连接后继续
+func WaitForNetworkConnected() {
+	// 延时 5 秒
+	timeout := time.Second * 5
+
+	for {
+		conn, err := net.DialTimeout("tcp", "baidu.com:80", timeout)
+		if err != nil {
+			log.Printf("网络未连接：%s。%s 后重试...", err, timeout)
+			// 等待 5 秒后重试
+			time.Sleep(timeout)
+			continue
+		}
+
+		// 网络已连接
+		conn.Close()
+		break
+	}
 }

--- a/util/net.go
+++ b/util/net.go
@@ -1,11 +1,9 @@
 package util
 
 import (
-	"log"
 	"net"
 	"net/http"
 	"strings"
-	"time"
 )
 
 // IsPrivateNetwork 是否为私有地址
@@ -48,24 +46,4 @@ func GetRequestIPStr(r *http.Request) (addr string) {
 		addr = addr + " ,Forwarded-For: " + r.Header.Get("X-Forwarded-For")
 	}
 	return addr
-}
-
-// WaitForNetworkConnected 等待网络连接后继续
-func WaitForNetworkConnected() {
-	// 延时 5 秒
-	timeout := time.Second * 5
-
-	for {
-		conn, err := net.DialTimeout("tcp", "baidu.com:80", timeout)
-		if err != nil {
-			log.Printf("网络未连接：%s。%s 后重试...", err, timeout)
-			// 等待 5 秒后重试
-			time.Sleep(timeout)
-			continue
-		}
-
-		// 网络已连接
-		conn.Close()
-		break
-	}
 }


### PR DESCRIPTION
# What does this PR do?
No more delay on first run.

Fixes #709.

# Motivation
#709

# Additional Notes
To do this, make sure the service waits for the network to be ready before starting:

Systemd configures dependencies with `Dependencies`. e.g. https://github.com/kardianos/service/blob/fffe6c52ed0fd8653543bbe72432dbf6ea02f300/example/logging/main.go#L73

Windows uses `DelayedAutoStart` to change the startup type to `自动(延迟启动)` (wait for the `自动` service to finish starting before starting). e.g. https://github.com/Graylog2/collector-sidecar/blob/e10b4c66dc1cc683a2168521fba414bcb855c0da/services/service_options_windows.go#L22

Ref: https://stackoverflow.com/a/25575496