### PR TITLE
chore(web): hide `DnsID` when `idLabel` is empty

### DIFF
--- a/web/writing.html
+++ b/web/writing.html
@@ -535,7 +535,12 @@
       document.getElementsByName("DnsName").forEach(e => e.addEventListener('click', e => {
         const dnsInfo = dnsProviders.find(d => d.id == e.target.value);
         const dnsIDElem = document.getElementById('DnsID');
-        dnsIDElem.disabled = !(dnsInfo.idLabel);
+
+        // idLabel 为空时禁用和隐藏 DnsID
+        const isIdLabelEmpty = !(dnsInfo.idLabel)
+        dnsIDElem.disabled = isIdLabelEmpty;
+        dnsIDElem.hidden = isIdLabelEmpty;
+
         if (dnsInfo.idLabel) {
           dnsIDElem.value ||= beforeDnsID;
         } else {

--- a/web/writing.html
+++ b/web/writing.html
@@ -536,10 +536,8 @@
         const dnsInfo = dnsProviders.find(d => d.id == e.target.value);
         const dnsIDElem = document.getElementById('DnsID');
 
-        // idLabel 为空时禁用和隐藏 DnsID
-        const isIdLabelEmpty = !(dnsInfo.idLabel)
-        dnsIDElem.disabled = isIdLabelEmpty;
-        dnsIDElem.hidden = isIdLabelEmpty;
+        // idLabel 为空时隐藏 DnsID
+        dnsIDElem.hidden = !(dnsInfo.idLabel);
 
         if (dnsInfo.idLabel) {
           dnsIDElem.value ||= beforeDnsID;


### PR DESCRIPTION
# What does this PR do?
Hide `DnsID` when `idLabel` is empty.
Fixes #738.

# Motivation
#738

# Additional Notes
