### PR TITLE
ci(release): add Homebrew

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   push:
     # Sequence of patterns matched against refs/tags
     tags:
-    - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+      - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
 
 permissions:
   contents: write
@@ -33,3 +33,27 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  homebrew:
+    needs: goreleaser
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/homebrew/ubuntu22.04:master
+    steps:
+      - name: Set up Homebrew
+        uses: Homebrew/actions/setup-homebrew@master
+        with:
+          test-bot: false
+
+      - name: Configure Git user
+        uses: Homebrew/actions/git-user-config@master
+
+      - name: Tap formulae repo
+        run: brew tap ivaquero/chinese
+
+      - name: Bump formulae
+        uses: Homebrew/actions/bump-formulae@master
+        with:
+          # Custom GitHub access token with only the 'workflow' scope enabled
+          token: ${{ secrets.HOMEBREW_COMMITTER_TOKEN }}
+          formulae: ddns-go ivaquero/chinese/ddns-go


### PR DESCRIPTION
# What does this PR do?
Automatically bump Homebrew's ddns-go after release.

Fixes #740.

# Motivation
#740

# Additional Notes
Ref: https://github.com/Homebrew/actions/tree/master/bump-formulae#usage

> One should use the [Personal Access Token](https://github.com/settings/tokens/new?scopes=public_repo,workflow) for `token` input to this Action, not the default `GITHUB_TOKEN`, because `brew bump-formula-pr` creates a fork of the formula's tap repository (if needed) and then creates a pull request.

Following https://docs.github.com/zh/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository, please enter the [Personal Access Token (`workflow` scope enabled)](https://github.com/settings/tokens/new?scopes=public_repo,workflow) into the secret `HOMEBREW_COMMITTER_TOKEN`.
