### PR TITLE
perf(domains): use suffixarray to lookup `staticMainDomains`

### DIFF
--- a/config/domains_test.go
+++ b/config/domains_test.go
@@ -22,7 +22,8 @@ func TestParseDomainArr(t *testing.T) {
 		{DomainName: "test.mydomain.com", SubDomain: "test2", CustomParams: "Line=oversea&RecordId=123"},
 	}
 
-	parsedDomains := checkParseDomains(domains)
+	parser := newDomainParser()
+	parsedDomains := parser.checkParseDomains(domains)
 	for i := 0; i < len(parsedDomains); i++ {
 		if parsedDomains[i].DomainName != result[i].DomainName ||
 			parsedDomains[i].SubDomain != result[i].SubDomain ||


### PR DESCRIPTION
# What does this PR do?
Use the suffix array instead of for range to lookup `staticMainDomains`. Also add `ha.cn` to `staticMainDomains`.

Fixes #750.

# Motivation
https://github.com/Cgboal/DomainParser

# Additional Notes
- https://github.com/Cgboal/DomainParser
- https://pkg.go.dev/index/suffixarray
- https://pkg.go.dev/sync#Once
- https://geektutu.com/post/hpg-sync-once.html
- https://help.aliyun.com/document_detail/35751.html#section-htk-ycd-b2b