### PR TITLE
fix(GoDaddy): use `@` as name when subdomain is missing

### DIFF
--- a/config/domains.go
+++ b/config/domains.go
@@ -45,7 +45,7 @@ func (d Domain) GetFullDomain() string {
 }
 
 // GetSubDomain 获得子域名，为空返回@
-// 阿里云/腾讯云/dnspod/namecheap 需要
+// 阿里云/腾讯云/dnspod/GoDaddy/namecheap 需要
 func (d Domain) GetSubDomain() string {
 	if d.SubDomain != "" {
 		return d.SubDomain

--- a/dns/godaddy.go
+++ b/dns/godaddy.go
@@ -72,7 +72,7 @@ func (g *GoDaddyDNS) updateDomainRecord(recordType string, ipAddr string, domain
 	for _, domain := range domains {
 		err := g.sendReq(http.MethodPut, recordType, domain, &godaddyRecords{godaddyRecord{
 			Data: ipAddr,
-			Name: domain.SubDomain,
+			Name: domain.GetSubDomain(),
 			TTL:  g.ttl,
 			Type: recordType,
 		}})
@@ -107,7 +107,7 @@ func (g *GoDaddyDNS) sendReq(method string, rType string, domain *config.Domain,
 		}
 	}
 	path := fmt.Sprintf("https://api.godaddy.com/v1/domains/%s/records/%s/%s",
-		domain.DomainName, rType, domain.SubDomain)
+		domain.DomainName, rType, domain.GetSubDomain())
 
 	req, err := http.NewRequest(method, path, body)
 	if err != nil {


### PR DESCRIPTION
# What does this PR do?
Using `@` as the name prevents updating all records in the domain if the subdomain is lost.

Fixes #769.

# Motivation
#769

# Additional Notes
https://developer.godaddy.com/doc/endpoint/domains#/v1/recordReplaceTypeName
