### PR TITLE
fix: no more Restricted Shell

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,6 @@ LABEL name=ddns-go
 LABEL url=https://github.com/jeessy2/ddns-go
 
 WORKDIR /app
-RUN apk add --no-cache bash
 COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
 ENV TZ=Asia/Shanghai
 COPY --from=builder /app/ddns-go /app/ddns-go

--- a/config/config.go
+++ b/config/config.go
@@ -231,7 +231,7 @@ func (conf *DnsConfig) getAddrFromCmd(addrType string) string {
 		if err != nil {
 			execCmd = exec.Command("sh", "-c", cmd)
 		} else {
-			execCmd = exec.Command("bash", "-rc", cmd)
+			execCmd = exec.Command("bash", "-c", cmd)
 		}
 	}
 	// run cmd


### PR DESCRIPTION
# What does this PR do?

No longer running commands with Restricted Shell, as some Shells don't support it.

Determining whether a Restricted Shell is supported may add unnecessary complexity.

Fixes #771.

# Motivation

#771

# Additional Notes

The following code can be used to fallback when a Restricted Shell is not supported:

```go
// run cmd
out, err := execCmd.CombinedOutput()
str := string(out)
if err != nil && strings.Contains(str, "bash: illegal option -r") {
	// 如果不支持受限 Shell 则使用 `bash -c` 运行命令
	// https://github.com/jeessy2/ddns-go/issues/771
	execCmd = exec.Command("bash", "-c", cmd)
	out, err = execCmd.CombinedOutput()

	if err != nil {
		log.Printf("获取%s结果失败! 未能成功执行命令：%s，错误：%q，退出状态码：%s\n", addrType, execCmd.String(), out, err)
		return ""
	}

} else {
	log.Printf("获取%s结果失败! 未能成功执行命令：%s，错误：%q，退出状态码：%s\n", addrType, execCmd.String(), out, err)
	return ""
}
```