### PR TITLE
chore: use HEAD commit as version when tag is missing

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -71,7 +71,7 @@ body:
   - type: input
     attributes:
       label: 版本
-      description: ddns-go 的版本或 commit，可运行 `ddns-go -v` 查看版本
+      description: ddns-go 的版本或 commit（可在网页右上角找到，或运行 `ddns-go -v` 查看版本）
       placeholder: v0.0.1
     validations:
       required: true

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 .PHONY: build clean test test-race
 
-VERSION=$(shell git describe --tags `git rev-list --tags --max-count=1`)
+# 如果找不到 tag 则使用 HEAD commit
+VERSION=$(shell git describe --tags `git rev-list --tags --max-count=1` 2>/dev/null || git rev-parse --short HEAD)
 BUILD_TIME=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 BIN=ddns-go
 DIR_SRC=.


### PR DESCRIPTION
# What does this PR do?

Use the HEAD commit as the ddns-go version if the tag is missing.

Also, add more instructions to `bug_report.yml` on how to find the ddns-go version.

Fixes #776.

# Motivation

#776

# Additional Notes
