### PR TITLE
docs: namecheap don't supports ipv6 ddns

### DIFF
--- a/web/writing.html
+++ b/web/writing.html
@@ -400,7 +400,7 @@
         id: 'namecheap',
         idLabel: '',
         secretLabel: 'Password',
-        helpHtml: "<a target='_blank' href='https://www.namecheap.com/support/knowledgebase/article.aspx/36/11/how-do-i-start-using-dynamic-dns/'>如何开启namecheap动态域名解析</a>"
+        helpHtml: "<a target='_blank' href='https://www.namecheap.com/support/knowledgebase/article.aspx/36/11/how-do-i-start-using-dynamic-dns/'>如何开启namecheap动态域名解析，Namecheap DDNS 不支持更新 IPv6！ </a>"
       },
       {
         name: 'NameSilo',


### PR DESCRIPTION
# What does this PR do?
增加 Namecheap DDNS 不支持更新 IPv6 的说明


# Motivation

# Additional Notes
