### PR TITLE
feat: self update

### DIFF
--- a/main.go
+++ b/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/jeessy2/ddns-go/v5/config"
 	"github.com/jeessy2/ddns-go/v5/dns"
 	"github.com/jeessy2/ddns-go/v5/util"
+	"github.com/jeessy2/ddns-go/v5/util/update"
 	"github.com/jeessy2/ddns-go/v5/web"
 	"github.com/kardianos/service"
 )
@@ -23,6 +24,9 @@ import (
 // ddns-go 版本
 // ddns-go version
 var versionFlag = flag.Bool("v", false, "ddns-go 版本")
+
+// 更新 ddns-go
+var updateFlag = flag.Bool("u", false, "更新 ddns-go")
 
 // 监听地址
 var listen = flag.String("l", ":9876", "监听地址")
@@ -61,6 +65,10 @@ func main() {
 	flag.Parse()
 	if *versionFlag {
 		fmt.Println(version)
+		return
+	}
+	if *updateFlag {
+		update.Self(version)
 		return
 	}
 	if _, err := net.ResolveTCPAddr("tcp", *listen); err != nil {

--- a/util/semver/version.go
+++ b/util/semver/version.go
@@ -1,0 +1,118 @@
+// Based on https://github.com/Masterminds/semver/blob/v3.2.1/version.go
+
+package semver
+
+import (
+	"bytes"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// 在 init() 中创建的正则表达式的编译版本被缓存在这里，这样
+// 它只需要被创建一次。
+var versionRegex *regexp.Regexp
+
+// semVerRegex 是用于解析语义化版本的正则表达式。
+const semVerRegex string = `v?([0-9]+)(\.[0-9]+)?(\.[0-9]+)?` +
+	`(-([0-9A-Za-z\-]+(\.[0-9A-Za-z\-]+)*))?` +
+	`(\+([0-9A-Za-z\-]+(\.[0-9A-Za-z\-]+)*))?`
+
+// Version 表示单独的语义化版本。
+type Version struct {
+	major, minor, patch uint64
+}
+
+func init() {
+	versionRegex = regexp.MustCompile("^" + semVerRegex + "$")
+}
+
+// NewVersion 解析给定的版本并返回 Version 实例，如果
+// 无法解析该版本则返回错误。如果版本是类似于 SemVer 的版本，则会
+// 尝试将其转换为 SemVer。
+func NewVersion(v string) (*Version, error) {
+	m := versionRegex.FindStringSubmatch(v)
+	if m == nil {
+		return nil, fmt.Errorf("%s 不是有效的语义化版本", v)
+	}
+
+	sv := &Version{}
+
+	var err error
+	sv.major, err = strconv.ParseUint(m[1], 10, 64)
+	if err != nil {
+		return nil, fmt.Errorf("解析版本号时出错：%s", err)
+	}
+
+	if m[2] != "" {
+		sv.minor, err = strconv.ParseUint(strings.TrimPrefix(m[2], "."), 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("解析版本号时出错：%s", err)
+		}
+	} else {
+		sv.minor = 0
+	}
+
+	if m[3] != "" {
+		sv.patch, err = strconv.ParseUint(strings.TrimPrefix(m[3], "."), 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("解析版本号时出错：%s", err)
+		}
+	} else {
+		sv.patch = 0
+	}
+
+	return sv, nil
+}
+
+// String 将 Version 对象转换为字符串。
+// 注意，如果原始版本包含前缀 v，则转换后的版本将不包含 v。
+// 根据规范，语义版本不包含前缀 v，而在实现上则是可选的。
+func (v Version) String() string {
+	var buf bytes.Buffer
+
+	fmt.Fprintf(&buf, "%d.%d.%d", v.major, v.minor, v.patch)
+
+	return buf.String()
+}
+
+// GreaterThan 测试一个版本是否大于另一个版本。
+func (v *Version) GreaterThan(o *Version) bool {
+	return v.compare(o) > 0
+}
+
+// GreaterThanOrEqual 测试一个版本是否大于或等于另一个版本。
+func (v *Version) GreaterThanOrEqual(o *Version) bool {
+	return v.compare(o) >= 0
+}
+
+// compare 比较当前版本与另一个版本。如果当前版本小于另一个版本则返回 -1；如果两个版本相等则返回 0；如果当前版本大于另一个版本，则返回 1。
+//
+// 版本比较是基于 X.Y.Z 格式进行的。
+func (v *Version) compare(o *Version) int {
+	// 比较主版本号、次版本号和修订号。如果
+	// 发现差异则返回比较结果。
+	if d := compareSegment(v.major, o.major); d != 0 {
+		return d
+	}
+	if d := compareSegment(v.minor, o.minor); d != 0 {
+		return d
+	}
+	if d := compareSegment(v.patch, o.patch); d != 0 {
+		return d
+	}
+
+	return 0
+}
+
+func compareSegment(v, o uint64) int {
+	if v < o {
+		return -1
+	}
+	if v > o {
+		return 1
+	}
+
+	return 0
+}

--- a/util/semver/version_test.go
+++ b/util/semver/version_test.go
@@ -1,0 +1,207 @@
+// Based on https://github.com/Masterminds/semver/blob/v3.2.1/version_test.go
+
+package semver
+
+import "testing"
+
+func TestNewVersion(t *testing.T) {
+	tests := []struct {
+		version string
+		err     bool
+	}{
+		{"1.2.3", false},
+		{"1.2.3+test.01", false},
+		{"1.2.3-alpha.-1", false},
+		{"v1.2.3", false},
+		{"1.0", false},
+		{"v1.0", false},
+		{"1", false},
+		{"v1", false},
+		{"1.2.beta", true},
+		{"v1.2.beta", true},
+		{"foo", true},
+		{"1.2-5", false},
+		{"v1.2-5", false},
+		{"1.2-beta.5", false},
+		{"v1.2-beta.5", false},
+		{"\n1.2", true},
+		{"\nv1.2", true},
+		{"1.2.0-x.Y.0+metadata", false},
+		{"v1.2.0-x.Y.0+metadata", false},
+		{"1.2.0-x.Y.0+metadata-width-hyphen", false},
+		{"v1.2.0-x.Y.0+metadata-width-hyphen", false},
+		{"1.2.3-rc1-with-hyphen", false},
+		{"v1.2.3-rc1-with-hyphen", false},
+		{"1.2.3.4", true},
+		{"v1.2.3.4", true},
+		{"1.2.2147483648", false},
+		{"1.2147483648.3", false},
+		{"2147483648.3.0", false},
+
+		// Due to having 4 parts these should produce an error. See
+		// https://github.com/Masterminds/semver/issues/185 for the reason for
+		// these tests.
+		{"12.3.4.1234", true},
+		{"12.23.4.1234", true},
+		{"12.3.34.1234", true},
+
+		// The SemVer spec in a pre-release expects to allow [0-9A-Za-z-].
+		{"20221209-update-renovatejson-v4", false},
+	}
+
+	for _, tc := range tests {
+		_, err := NewVersion(tc.version)
+		if tc.err && err == nil {
+			t.Fatalf("expected error for version: %s", tc.version)
+		} else if !tc.err && err != nil {
+			t.Fatalf("error for version %s: %s", tc.version, err)
+		}
+	}
+}
+
+func TestParts(t *testing.T) {
+	v, err := NewVersion("1.2.3")
+	if err != nil {
+		t.Error("Error parsing version 1.2.3")
+	}
+
+	if v.major != 1 {
+		t.Error("major returning wrong value")
+	}
+	if v.minor != 2 {
+		t.Error("minor returning wrong value")
+	}
+	if v.patch != 3 {
+		t.Error("patch returning wrong value")
+	}
+}
+
+func TestCoerceString(t *testing.T) {
+	tests := []struct {
+		version  string
+		expected string
+	}{
+		{"1.2.3", "1.2.3"},
+		{"v1.2.3", "1.2.3"},
+		{"1.0", "1.0.0"},
+		{"v1.0", "1.0.0"},
+		{"1", "1.0.0"},
+		{"v1", "1.0.0"},
+	}
+
+	for _, tc := range tests {
+		v, err := NewVersion(tc.version)
+		if err != nil {
+			t.Errorf("Error parsing version %s", tc)
+		}
+
+		s := v.String()
+		if s != tc.expected {
+			t.Errorf("Error generating string. Expected '%s' but got '%s'", tc.expected, s)
+		}
+	}
+}
+
+func TestCompare(t *testing.T) {
+	tests := []struct {
+		v1       string
+		v2       string
+		expected int
+	}{
+		{"1.2.3", "1.5.1", -1},
+		{"2.2.3", "1.5.1", 1},
+		{"2.2.3", "2.2.2", 1},
+	}
+
+	for _, tc := range tests {
+		v1, err := NewVersion(tc.v1)
+		if err != nil {
+			t.Errorf("Error parsing version: %s", err)
+		}
+
+		v2, err := NewVersion(tc.v2)
+		if err != nil {
+			t.Errorf("Error parsing version: %s", err)
+		}
+
+		a := v1.compare(v2)
+		e := tc.expected
+		if a != e {
+			t.Errorf(
+				"Comparison of '%s' and '%s' failed. Expected '%d', got '%d'",
+				tc.v1, tc.v2, e, a,
+			)
+		}
+	}
+}
+
+func TestGreaterThan(t *testing.T) {
+	tests := []struct {
+		v1       string
+		v2       string
+		expected bool
+	}{
+		{"1.2.3", "1.5.1", false},
+		{"2.2.3", "1.5.1", true},
+		{"3.2-beta", "3.2-beta", false},
+		{"3.2.0-beta.1", "3.2.0-beta.5", false},
+		{"7.43.0-SNAPSHOT.99", "7.43.0-SNAPSHOT.103", false},
+		{"7.43.0-SNAPSHOT.99", "7.43.0-SNAPSHOT.BAR", false},
+	}
+
+	for _, tc := range tests {
+		v1, err := NewVersion(tc.v1)
+		if err != nil {
+			t.Errorf("Error parsing version: %s", err)
+		}
+
+		v2, err := NewVersion(tc.v2)
+		if err != nil {
+			t.Errorf("Error parsing version: %s", err)
+		}
+
+		a := v1.GreaterThan(v2)
+		e := tc.expected
+		if a != e {
+			t.Errorf(
+				"Comparison of '%s' and '%s' failed. Expected '%t', got '%t'",
+				tc.v1, tc.v2, e, a,
+			)
+		}
+	}
+}
+
+func TestGreaterThanOrEqual(t *testing.T) {
+	tests := []struct {
+		v1       string
+		v2       string
+		expected bool
+	}{
+		{"1.2.3", "1.5.1", false},
+		{"2.2.3", "1.5.1", true},
+		{"3.2-beta", "3.2-beta", true},
+		{"3.2-beta.4", "3.2-beta.2", true},
+		{"7.43.0-SNAPSHOT.FOO", "7.43.0-SNAPSHOT.103", true},
+	}
+
+	for _, tc := range tests {
+		v1, err := NewVersion(tc.v1)
+		if err != nil {
+			t.Errorf("Error parsing version: %s", err)
+		}
+
+		v2, err := NewVersion(tc.v2)
+		if err != nil {
+			t.Errorf("Error parsing version: %s", err)
+		}
+
+		a := v1.GreaterThanOrEqual(v2)
+		e := tc.expected
+		if a != e {
+			t.Errorf(
+				"Comparison of '%s' and '%s' failed. Expected '%t', got '%t'",
+				tc.v1, tc.v2, e, a,
+			)
+		}
+	}
+}

--- a/util/update/apply.go
+++ b/util/update/apply.go
@@ -1,0 +1,108 @@
+// Based on https://github.com/inconshreveable/go-update/blob/7a872911e5b39953310f0a04161f0d50c7e63755/apply.go
+
+package update
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+)
+
+// apply 使用给定的 io.Reader 的内容来更新 targetPath 的可执行文件。
+//
+// apply 执行以下操作以确保安全的跨平台更新：
+//
+// 1. 创建新文件 /path/to/target.new，并将更新文件的内容写入其中
+//
+// 2. 将 /path/to/target 重命名为 /path/to/target.old
+//
+// 3. 将 /path/to/target.new 重命名为 /path/to/target
+//
+// 4.如果最终的重命名成功，删除 /path/to/target.old 并返回无错误。
+//
+// 5. 如果最终重命名失败，尝试通过将 /path/to/target.old 重命名会
+// /path/to/target 进行回滚。
+//
+// 如果回滚操作失败，文件系统将处于不一致状态（第 4 步和第 5 步之间），
+// 既没有新的可执行文件，并且旧的可执行文件无法移动回其原始位置。在这种情况下，
+// 应该通知用户这个坏消息，并要求他们手动恢复。
+func apply(update io.Reader, targetPath string) error {
+	newBytes, err := io.ReadAll(update)
+	if err != nil {
+		return err
+	}
+
+	// 获取可执行文件所在的目录
+	updateDir := filepath.Dir(targetPath)
+	filename := filepath.Base(targetPath)
+
+	// 将新二进制的内容复制到新可执行文件中。
+	newPath := filepath.Join(updateDir, fmt.Sprintf("%s.new", filename))
+	fp, err := os.OpenFile(newPath, os.O_CREATE|os.O_WRONLY, 0755)
+	if err != nil {
+		return err
+	}
+	defer fp.Close()
+
+	_, err = io.Copy(fp, bytes.NewReader(newBytes))
+	if err != nil {
+		return err
+	}
+
+	// 如果我们不调用 fp.Close()，Windows 将不允许我们移动新可执行文件。
+	// 因为文件仍处于 "in use"（使用中）状态。
+	fp.Close()
+
+	// 这是我们将要移动可执行文件的位置，以便可以将更新的文件替代进来
+	oldPath := filepath.Join(updateDir, fmt.Sprintf("%s.old", filename))
+
+	// 删除任何现有的就执行文件 - 这在 Windows 上是必要的，原因有两个：
+	// 1. 成功更新后，Windows 无法删除 .old 文件，因为进程仍在运行
+	// 2. 如果目标文件已存在，Windows 重命名操作将失败
+	_ = os.Remove(oldPath)
+
+	// 将现有的可执行文件移到同一目录下的新文件中
+	err = os.Rename(targetPath, oldPath)
+	if err != nil {
+		return err
+	}
+
+	// 将新可执行文件移到目标位置
+	err = os.Rename(newPath, targetPath)
+
+	if err != nil {
+		// 移动失败
+		//
+		// 文件系统现在处于不良状态。我们已成功将现有的二进制文件移动到新位置，
+		// 但无法将新二进制文件移动到原来的位置。这意味着当前可执行文件的位置上没有文件！
+		// 尝试通过将旧二进制文件恢复到原始路径来回滚。
+		rerr := os.Rename(oldPath, targetPath)
+		if rerr != nil {
+			return err
+		}
+
+		return err
+	}
+
+	// 移动成功，删除旧的二进制文件
+	err = os.Remove(oldPath)
+	if err != nil {
+		if runtime.GOOS == "windows" {
+			// Windows 无法删除 .old 文件，因为进程仍在运行。删除会提示 "Access is denied"。
+			// 因此，启动外部进程来删除旧的二进制文件。
+			// 外部进程会等待一会以确保进程已退出。
+			//
+			// https://stackoverflow.com/a/73585620
+			exec.Command("cmd.exe", "/c", "ping 127.0.0.1 -n 2 > NUL & del "+oldPath).Start()
+			return nil
+		}
+
+		return err
+	}
+
+	return nil
+}

--- a/util/update/apply_test.go
+++ b/util/update/apply_test.go
@@ -1,0 +1,56 @@
+// Based on https://github.com/inconshreveable/go-update/blob/7a872911e5b39953310f0a04161f0d50c7e63755/apply_test.go
+
+package update
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"testing"
+)
+
+var (
+	oldFile = []byte{0xDE, 0xAD, 0xBE, 0xEF}
+	newFile = []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06}
+)
+
+func cleanup(path string) {
+	os.Remove(path)
+	os.Remove(fmt.Sprintf("%s.new", path))
+}
+
+// we write with a separate name for each test so that we can run them in parallel
+func writeOldFile(path string, t *testing.T) {
+	if err := os.WriteFile(path, oldFile, 0777); err != nil {
+		t.Fatalf("Failed to write file for testing preparation: %v", err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("Failed to stat file for testing preparation: %v", err)
+	}
+}
+
+func validateUpdate(path string, err error, t *testing.T) {
+	if err != nil {
+		t.Fatalf("Failed to update: %v", err)
+	}
+
+	buf, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("Failed to read file post-update: %v", err)
+	}
+
+	if !bytes.Equal(buf, newFile) {
+		t.Fatalf("File was not updated! Bytes read: %v, Bytes expected: %v", buf, newFile)
+	}
+}
+
+func TestApply(t *testing.T) {
+	t.Parallel()
+
+	fName := "TestApply"
+	defer cleanup(fName)
+	writeOldFile(fName, t)
+
+	err := apply(bytes.NewReader(newFile), fName)
+	validateUpdate(fName, err, t)
+}

--- a/util/update/arch.go
+++ b/util/update/arch.go
@@ -1,0 +1,28 @@
+// Based on https://github.com/creativeprojects/go-selfupdate/blob/v1.1.1/arch.go
+
+package update
+
+import (
+	"fmt"
+	"runtime"
+)
+
+const (
+	minARM = 5
+	maxARM = 7
+)
+
+// generateAdditionalArch 可以根据 CPU 类型使用
+func generateAdditionalArch() []string {
+	if runtime.GOARCH == "arm" && goarm >= minARM && goarm <= maxARM {
+		additionalArch := make([]string, 0, maxARM-minARM)
+		for v := goarm; v >= minARM; v-- {
+			additionalArch = append(additionalArch, fmt.Sprintf("armv%d", v))
+		}
+		return additionalArch
+	}
+	if runtime.GOARCH == "amd64" {
+		return []string{"x86_64"}
+	}
+	return []string{}
+}

--- a/util/update/arm.go
+++ b/util/update/arm.go
@@ -1,0 +1,11 @@
+// Based on https://github.com/creativeprojects/go-selfupdate/blob/v1.1.1/arm.go
+
+package update
+
+import (
+	// unsafe 用于从 runtime 包中获取私有变量
+	_ "unsafe"
+)
+
+//go:linkname goarm runtime.goarm
+var goarm uint8

--- a/util/update/decompress.go
+++ b/util/update/decompress.go
@@ -1,0 +1,89 @@
+// Based on https://github.com/creativeprojects/go-selfupdate/blob/v1.1.1/decompress.go
+
+package update
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"bytes"
+	"compress/gzip"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"path/filepath"
+	"strings"
+)
+
+var fileTypes = map[string]func(src io.Reader, cmd string) (io.Reader, error){
+	".zip":    unzip,
+	".tar.gz": untar,
+}
+
+// decompressCommand 解压缩给定源。从 'url' 参数中自动检测存档和压缩格式，'url' 参数表示 asset 的 URL，
+// 或简单的文件名（带扩展名）。
+// 返回 reader，用于读取解压缩后与 'cmd' 相应的命令。支持 '.zip' 和 '.tar.gz'
+//
+// 可能返回以下封装过的错误：
+//   - errCannotDecompressFile
+//   - errExecutableNotFoundInArchive
+func decompressCommand(src io.Reader, url, cmd string) (io.Reader, error) {
+	for ext, decompress := range fileTypes {
+		if strings.HasSuffix(url, ext) {
+			return decompress(src, cmd)
+		}
+	}
+	log.Print("未压缩文件")
+	return src, nil
+}
+
+func unzip(src io.Reader, cmd string) (io.Reader, error) {
+	// 解压 Zip 格式时需要文件大小。
+	// 因此我们需要先将 HTTP 响应读取到缓冲区中。
+	buf, err := io.ReadAll(src)
+	if err != nil {
+		return nil, fmt.Errorf("%w zip 文件: %v", errCannotDecompressFile, err)
+	}
+
+	r := bytes.NewReader(buf)
+	z, err := zip.NewReader(r, r.Size())
+	if err != nil {
+		return nil, fmt.Errorf("%w zip 文件: %s", errCannotDecompressFile, err)
+	}
+
+	for _, file := range z.File {
+		_, name := filepath.Split(file.Name)
+		if !file.FileInfo().IsDir() && matchExecutableName(cmd, name) {
+			return file.Open()
+		}
+	}
+
+	return nil, fmt.Errorf("在 zip 文件中%w：%q", errExecutableNotFoundInArchive, cmd)
+}
+
+func untar(src io.Reader, cmd string) (io.Reader, error) {
+	gz, err := gzip.NewReader(src)
+	if err != nil {
+		return nil, fmt.Errorf("%w tar.gz 文件: %s", errCannotDecompressFile, err)
+	}
+
+	t := tar.NewReader(gz)
+	for {
+		h, err := t.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("%w tar.gz 文件：%s", errCannotDecompressFile, err)
+		}
+		_, name := filepath.Split(h.Name)
+		if matchExecutableName(cmd, name) {
+			return t, nil
+		}
+	}
+	return nil, fmt.Errorf("在 tar.gz 文件中%w：%q", errExecutableNotFoundInArchive, cmd)
+}
+
+func matchExecutableName(cmd, target string) bool {
+	return cmd == target || cmd+".exe" == target
+}

--- a/util/update/decompress_test.go
+++ b/util/update/decompress_test.go
@@ -1,0 +1,74 @@
+// Based on https://github.com/creativeprojects/go-selfupdate/blob/v1.1.1/decompress_test.go
+
+package update
+
+import (
+	"bytes"
+	"io"
+	"strings"
+	"testing"
+)
+
+var buf = []byte{'a', 'b', 'c'}
+
+func TestCompressionNotRequired(t *testing.T) {
+	want := bytes.NewReader(buf)
+	r, err := decompressCommand(want, "https://github.com/foo/bar/releases/download/v1.2.3/foo", "foo")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	have, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Equal(buf, have) {
+		t.Errorf("expected %v, got %v", buf, have)
+	}
+}
+
+func TestMatchExecutableName(t *testing.T) {
+	testData := []struct {
+		cmd    string
+		target string
+		found  bool
+	}{
+		{"gostuff", "gostuff", true},
+		{"gostuff", "gostuff_linux_x86_64", false},
+		{"gostuff", "gostuff_darwin_amd64", false},
+		{"gostuff", "gostuff.exe", true},
+		{"gostuff", "gostuff_windows_amd64.exe", false},
+	}
+
+	for _, testItem := range testData {
+		t.Run(testItem.target, func(t *testing.T) {
+			if matchExecutableName(testItem.cmd, testItem.target) != testItem.found {
+				t.Errorf("Expected '%t' but got '%t'", testItem.found, matchExecutableName(testItem.cmd, testItem.target))
+			}
+		})
+	}
+}
+
+func TestErrorFromReader(t *testing.T) {
+	extensions := []string{
+		"zip",
+		"tar.gz",
+	}
+
+	for _, extension := range extensions {
+		t.Run(extension, func(t *testing.T) {
+			reader, err := decompressCommand(bytes.NewReader(buf), "foo."+extension, "foo."+extension)
+			if err != nil {
+				if !strings.Contains(err.Error(), errCannotDecompressFile.Error()) {
+					t.Fatalf("Expected error: EOF, got: %v", err)
+				}
+			} else {
+				_, err = io.ReadAll(reader)
+				if err == nil {
+					t.Fatalf("An error is expected but got nil.")
+				}
+			}
+		})
+	}
+}

--- a/util/update/detect.go
+++ b/util/update/detect.go
@@ -1,0 +1,108 @@
+// Based on https://github.com/creativeprojects/go-selfupdate/blob/v1.1.1/detect.go
+
+package update
+
+import (
+	"fmt"
+	"log"
+	"runtime"
+	"strings"
+
+	"github.com/jeessy2/ddns-go/v5/util/semver"
+)
+
+// detectLatest 尝试从源提供者获取版本信息。
+func detectLatest(repo string) (latest *Latest, found bool, err error) {
+	rel, err := getLatest(repo)
+	if err != nil {
+		return nil, false, err
+	}
+
+	asset, ver, found := findAsset(rel)
+	if !found {
+		return nil, false, nil
+	}
+
+	return newLatest(asset, ver), true, nil
+}
+
+// findAsset 返回最新的 asset
+func findAsset(rel *Release) (*Asset, *semver.Version, bool) {
+	// 将检测到的架构放在列表的末尾，对于 ARM 来说这是可以的。
+	// 因为附加的架构比通用架构更准确
+	for _, arch := range append(generateAdditionalArch(), runtime.GOARCH) {
+		asset, version, found := findAssetForArch(arch, rel)
+		if found {
+			return asset, version, found
+		}
+	}
+
+	return nil, nil, false
+}
+
+func findAssetForArch(arch string, rel *Release,
+) (asset *Asset, version *semver.Version, found bool) {
+	var release *Release
+
+	// 从 release 列表中查找最新的版本。
+	// GitHub API 返回的列表按照创建日期的顺序排列。
+	if a, v, ok := findAssetFromRelease(rel, getSuffixes(arch)); ok {
+		if release == nil || v.GreaterThan(version) {
+			version = v
+			asset = a
+			release = rel
+		}
+	}
+
+	if release == nil {
+		log.Printf("未找到适用于 %s/%s 的任何 release", runtime.GOOS, runtime.GOARCH)
+		return nil, nil, false
+	}
+
+	return asset, version, true
+}
+
+func findAssetFromRelease(rel *Release, suffixes []string) (*Asset, *semver.Version, bool) {
+	if rel == nil {
+		log.Print("没有源 release 信息")
+		return nil, nil, false
+	}
+
+	// 如果无法解析版本文本，则表示该文本不符合语义化版本规范，应该跳过。
+	ver, err := semver.NewVersion(rel.tagName)
+	if err != nil {
+		log.Printf("无法解析语义化版本：%s", rel.tagName)
+		return nil, nil, false
+	}
+
+	for _, asset := range rel.assets {
+		if assetMatchSuffixes(asset.name, suffixes) {
+			return &asset, ver, true
+		}
+	}
+
+	log.Printf("未在 release %s 中找到合适的 asset", rel.tagName)
+	return nil, nil, false
+}
+
+func assetMatchSuffixes(name string, suffixes []string) bool {
+	for _, suffix := range suffixes {
+		if strings.HasSuffix(name, suffix) { // 需要版本、架构等
+			// 假设唯一的构件被匹配（或者第一个匹配将足够）
+			return true
+		}
+	}
+	return false
+}
+
+// getSuffixes 返回所有要与 asset 进行检查的候选后缀
+//
+// TODO: 由于缺失获取 MIPS 架构 float 的方法，所以目前无法正确获取 MIPS 架构的后缀。
+func getSuffixes(arch string) []string {
+	suffixes := make([]string, 0)
+	for _, ext := range []string{".zip", ".tar.gz"} {
+		suffix := fmt.Sprintf("%s_%s%s", runtime.GOOS, arch, ext)
+		suffixes = append(suffixes, suffix)
+	}
+	return suffixes
+}

--- a/util/update/errors.go
+++ b/util/update/errors.go
@@ -1,0 +1,10 @@
+// Based on https://github.com/creativeprojects/go-selfupdate/blob/v1.1.1/errors.go
+
+package update
+
+import "errors"
+
+var (
+	errCannotDecompressFile        = errors.New("无法解压")
+	errExecutableNotFoundInArchive = errors.New("找不到可执行文件")
+)

--- a/util/update/latest.go
+++ b/util/update/latest.go
@@ -1,0 +1,25 @@
+// Based on https://github.com/creativeprojects/go-selfupdate/blob/v1.1.1/release.go
+
+package update
+
+import "github.com/jeessy2/ddns-go/v5/util/semver"
+
+// Latest 表示当前操作系统和架构的最新 release asset。
+type Latest struct {
+	//Name 是 asset 的文件名
+	Name string
+	// URL 是 release 上传文件的 URL
+	URL string
+	// version 是解析后的 *Version
+	Version *semver.Version
+}
+
+func newLatest(asset *Asset, ver *semver.Version) *Latest {
+	latest := &Latest{
+		Name:    asset.name,
+		URL:     asset.url,
+		Version: ver,
+	}
+
+	return latest
+}

--- a/util/update/package.go
+++ b/util/update/package.go
@@ -1,0 +1,76 @@
+package update
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"runtime"
+
+	"github.com/jeessy2/ddns-go/v5/util"
+	"github.com/jeessy2/ddns-go/v5/util/semver"
+)
+
+// Self 更新 ddns-go 到最新版本（如果可用）。
+func Self(version string) {
+	// 如果不为语义化版本立即退出
+	v, err := semver.NewVersion(version)
+	if err != nil {
+		log.Printf("无法更新！因为：%v", err)
+		return
+	}
+
+	latest, found, err := detectLatest("jeessy2/ddns-go")
+	if err != nil {
+		log.Printf("检测最新版本时发生错误：%v", err)
+		return
+	}
+	if !found {
+		log.Printf("无法从 GitHub 仓库找到 %s/%s 的最新版本", runtime.GOOS, runtime.GOARCH)
+		return
+	}
+	if v.GreaterThanOrEqual(latest.Version) {
+		log.Printf("当前版本（%s）是最新的", version)
+		return
+	}
+
+	exe, err := os.Executable()
+	if err != nil {
+		log.Printf("找不到可执行路径：%v", err)
+		return
+	}
+
+	if err = to(latest.URL, latest.Name, exe); err != nil {
+		log.Printf("更新二进制文件时发生错误：%v", err)
+		return
+	}
+
+	log.Printf("成功更新到 v%s", latest.Version.String())
+}
+
+// to 从 assetURL 下载可执行文件，并用下载的文件替换当前的可执行文件。
+// 这个函数是用于更新二进制文件的低级 API。因为它不使用源提供者，而是直接通过 HTTP 从 URL 下载 asset 。
+// 所以这个函数不能用于更新私有仓库的 release。
+// cmdPath 是命令可执行文件的文件路径。
+func to(assetURL, assetFileName, cmdPath string) error {
+	src, err := downloadAssetFromURL(assetURL)
+	if err != nil {
+		return err
+	}
+	defer src.Close()
+	return decompressAndUpdate(src, assetFileName, assetURL, cmdPath)
+}
+
+func downloadAssetFromURL(url string) (rc io.ReadCloser, err error) {
+	client := util.CreateHTTPClient()
+	resp, err := client.Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("从 %s 下载 release 失败：%v", url, err)
+	}
+	if resp.StatusCode >= 300 {
+		resp.Body.Close()
+		return nil, fmt.Errorf("从 %s 下载 release 失败，返回状态码：%d", url, resp.StatusCode)
+	}
+
+	return resp.Body, nil
+}

--- a/util/update/release.go
+++ b/util/update/release.go
@@ -1,0 +1,64 @@
+// Based on https://github.com/creativeprojects/go-selfupdate/blob/v1.1.1/github_release.go
+// and https://github.com/creativeprojects/go-selfupdate/blob/v1.1.1/github_source.go
+
+package update
+
+import (
+	"fmt"
+
+	"github.com/jeessy2/ddns-go/v5/util"
+)
+
+type Release struct {
+	tagName string
+	assets  []Asset
+}
+
+type Asset struct {
+	name string
+	url  string
+}
+
+// ReleaseResp 表示仓库中的 GitHub release 和 asset。
+type ReleaseResp struct {
+	TagName string `json:"tag_name,omitempty"`
+	Assets  []struct {
+		Name               string `json:"name,omitempty"`
+		BrowserDownloadURL string `json:"browser_download_url,omitempty"`
+	} `json:"assets,omitempty"`
+}
+
+// getLatest 列出仓库的最新 release 并返回包装过的 Release
+//
+// GitHub API 文档：https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#get-the-latest-release
+func getLatest(repo string) (*Release, error) {
+	u := fmt.Sprintf("https://api.github.com/repos/%s/releases/latest", repo)
+
+	client := util.CreateHTTPClient()
+	resp, err := client.Get(u)
+	if err != nil {
+		return nil, err
+	}
+
+	var result ReleaseResp
+	err = util.GetHTTPResponse(resp, u, err, &result)
+	if err != nil {
+		return nil, err
+	}
+
+	return newRelease(&result), err
+}
+
+func newRelease(from *ReleaseResp) *Release {
+	release := &Release{
+		tagName: from.TagName,
+		assets:  make([]Asset, len(from.Assets)),
+	}
+	for i, fromAsset := range from.Assets {
+		release.assets[i] = Asset{
+			name: fromAsset.Name,
+			url:  fromAsset.BrowserDownloadURL,
+		}
+	}
+	return release
+}

--- a/util/update/update.go
+++ b/util/update/update.go
@@ -1,0 +1,18 @@
+// Based on https://github.com/creativeprojects/go-selfupdate/blob/v1.1.1/update.go
+
+package update
+
+import (
+	"io"
+	"path/filepath"
+)
+
+func decompressAndUpdate(src io.Reader, assetName, assetURL, cmdPath string) error {
+	_, cmd := filepath.Split(cmdPath)
+	asset, err := decompressCommand(src, assetName, cmd)
+	if err != nil {
+		return err
+	}
+
+	return apply(asset, cmdPath)
+}


### PR DESCRIPTION
# What does this PR do?

Added packages `update` and `semver` that can be used for selfupdate.

Fixes #595.

# Motivation

#595

# Additional Notes

Most of the code was copied from [go-selfupdate](https://github.com/creativeprojects/go-selfupdate), [go-update](https://github.com/inconshreveable/go-update) and [semver](https://github.com/Masterminds/semver). Most of the unneeded code has been removed, so there is no need to add new dependencies.

In addition, users with the `mips` arch will not be able to selfupdate, as there is no way to get the float of the MIPS arch.

Tested OS and arch:
- [x] linux/amd64
- [x] linux/arm64
- [x] windows/amd64