### PR TITLE
refactor: set `InsecureSkipVerify` only once

### DIFF
--- a/main.go
+++ b/main.go
@@ -80,7 +80,7 @@ func main() {
 		os.Setenv(util.ConfigFilePathENV, absPath)
 	}
 	if *skipVerify {
-		os.Setenv(util.SkipVerifyENV, "true")
+		util.SetInsecureSkipVerify()
 	}
 	if *customDNSServer != "" {
 		util.NewDialerResolver(*customDNSServer + ":53")

--- a/util/http_client_util.go
+++ b/util/http_client_util.go
@@ -5,11 +5,8 @@ import (
 	"crypto/tls"
 	"net"
 	"net/http"
-	"os"
 	"time"
 )
-
-const SkipVerifyENV = "DDNS_SKIP_VERIFY"
 
 var dialer = &net.Dialer{
 	Timeout:   30 * time.Second,
@@ -31,8 +28,6 @@ var defaultTransport = &http.Transport{
 
 // CreateHTTPClient Create Default HTTP Client
 func CreateHTTPClient() *http.Client {
-	// SkipVerfiry
-	defaultTransport.TLSClientConfig = &tls.Config{InsecureSkipVerify: os.Getenv(SkipVerifyENV) == "true"}
 	return &http.Client{
 		Timeout:   30 * time.Second,
 		Transport: defaultTransport,
@@ -74,18 +69,23 @@ var noProxyTcp6Transport = &http.Transport{
 // CreateNoProxyHTTPClient Create NoProxy HTTP Client
 func CreateNoProxyHTTPClient(network string) *http.Client {
 	if network == "tcp6" {
-		// SkipVerfiry
-		noProxyTcp6Transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: os.Getenv(SkipVerifyENV) == "true"}
 		return &http.Client{
 			Timeout:   30 * time.Second,
 			Transport: noProxyTcp6Transport,
 		}
 	}
 
-	// SkipVerfiry
-	noProxyTcp4Transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: os.Getenv(SkipVerifyENV) == "true"}
 	return &http.Client{
 		Timeout:   30 * time.Second,
 		Transport: noProxyTcp4Transport,
+	}
+}
+
+// SetInsecureSkipVerify 将所有 http.Transport 的 InsecureSkipVerify 设置为 true
+func SetInsecureSkipVerify() {
+	transports := []*http.Transport{defaultTransport, noProxyTcp4Transport, noProxyTcp6Transport}
+
+	for _, transport := range transports {
+		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 	}
 }


### PR DESCRIPTION
# What does this PR do?

Set `InsecureSkipVerify` to true for all `http.Transport` only once.

# Motivation

https://github.com/jeessy2/ddns-go/pull/821#issuecomment-1681780798

# Additional Notes
