### PR TITLE
docs: add arch user repository page url

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@
   brew install ddns-go
   ```
 
-- Arch Linux 用户可以使用该AUR打包：[https://aur.archlinux.org/packages/ddns-go-bin]
+- [可选] Arch Linux 用户可以使用该AUR打包：[https://aur.archlinux.org/packages/ddns-go-bin]
+
   ```bash
   yay -S ddns-go-bin
   ```

--- a/README.md
+++ b/README.md
@@ -4,14 +4,15 @@
 
 自动获得你的公网 IPv4 或 IPv6 地址，并解析到对应的域名服务。
 
-- [特性](#特性)
-- [系统中使用](#系统中使用)
-- [Docker中使用](#docker中使用)
-- [使用IPv6](#使用ipv6)
-- [Webhook](#webhook)
-- [Callback](#callback)
-- [界面](#界面)
-- [开发&自行编译](#开发自行编译)
+- [ddns-go](#ddns-go)
+  - [特性](#特性)
+  - [系统中使用](#系统中使用)
+  - [Docker中使用](#docker中使用)
+  - [使用IPv6](#使用ipv6)
+  - [Webhook](#webhook)
+  - [Callback](#callback)
+  - [界面](#界面)
+  - [开发\&自行编译](#开发自行编译)
 
 ## 特性
 
@@ -39,6 +40,11 @@
 
   ```bash
   brew install ddns-go
+  ```
+
+- Arch Linux 用户可以使用该AUR打包：[https://aur.archlinux.org/packages/ddns-go-bin]
+  ```bash
+  yay -S ddns-go-bin
   ```
 
 - 双击运行, 如没有找到配置, 程序将自动打开 http://127.0.0.1:9876


### PR DESCRIPTION
# What does this PR do?
Add AUR reference.
# Motivation
I have taken up maintaining the AUR PKGBUILD. Arch users can know that they may install from AUR directly.
# Additional Notes
