### PR TITLE
build: add curl&grep

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN apk add --no-cache git make tzdata \
 FROM alpine
 LABEL name=ddns-go
 LABEL url=https://github.com/jeessy2/ddns-go
+RUN apk add --no-cache curl grep
 
 WORKDIR /app
 COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo


### PR DESCRIPTION
# What does this PR do?

dockerfile 中添加了 grep 和 curl。

# Motivation

有些场景想从路由器的 restful api 拿到公网 IP，添加这两个包便于自定义命令获取内网。

# Additional Notes

感谢作者搞了个好用的ddns工具。