### PR TITLE
refactor(domains): use publicsuffix to parse

### DIFF
--- a/config/domains.go
+++ b/config/domains.go
@@ -129,9 +129,9 @@ func checkParseDomains(domainArr []string) (domains []*Domain) {
 			}
 			domain.DomainName = domainName
 
-			domainNameIdx := strings.Index(domainStr, domainName)
-			if domainNameIdx > 0 {
-				domain.SubDomain = domainStr[:domainNameIdx-1]
+			domainLen := len(domainStr) - len(domainName) - 1
+			if domainLen > 0 {
+				domain.SubDomain = domainStr[:domainLen]
 			}
 		case 2: // 使用冒号分隔，为 子域名:根域名 格式
 			sp := strings.Split(dp[1], ".")

--- a/config/domains_test.go
+++ b/config/domains_test.go
@@ -6,7 +6,7 @@ import (
 
 // TestParseDomainArr 测试 parseDomainArr
 func TestParseDomainArr(t *testing.T) {
-	domains := []string{"mydomain.com", "test.mydomain.com", "test2.test.mydomain.com", "mydomain.com.cn",
+	domains := []string{"mydomain.com", "test.mydomain.com", "test2.test.mydomain.com", "mydomain.com.mydomain.com", "mydomain.com.cn",
 		"test.mydomain.com.cn", "test:mydomain.com.cn",
 		"test.mydomain.com?Line=oversea&RecordId=123", "test.mydomain.com.cn?Line=oversea&RecordId=123",
 		"test2:test.mydomain.com?Line=oversea&RecordId=123"}
@@ -14,6 +14,7 @@ func TestParseDomainArr(t *testing.T) {
 		{DomainName: "mydomain.com", SubDomain: ""},
 		{DomainName: "mydomain.com", SubDomain: "test"},
 		{DomainName: "mydomain.com", SubDomain: "test2.test"},
+		{DomainName: "mydomain.com", SubDomain: "mydomain.com"},
 		{DomainName: "mydomain.com.cn", SubDomain: ""},
 		{DomainName: "mydomain.com.cn", SubDomain: "test"},
 		{DomainName: "mydomain.com.cn", SubDomain: "test"},

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.20
 require (
 	github.com/kardianos/service v1.2.2
 	github.com/wagslane/go-password-validator v0.3.0
+	golang.org/x/net v0.19.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/kardianos/service v1.2.2 h1:ZvePhAHfvo0A7Mftk/tEzqEZ7Q4lgnR8sGz4xu1YX
 github.com/kardianos/service v1.2.2/go.mod h1:CIMRFEJVL+0DS1a3Nx06NaMn4Dz63Ng6O7dl0qH0zVM=
 github.com/wagslane/go-password-validator v0.3.0 h1:vfxOPzGHkz5S146HDpavl0cw1DSVP061Ry2PX0/ON6I=
 github.com/wagslane/go-password-validator v0.3.0/go.mod h1:TI1XJ6T5fRdRnHqHt14pvy1tNVnrwe7m3/f1f2fDphQ=
+golang.org/x/net v0.19.0 h1:zTwKpTd2XuCqf8huc7Fo2iSy+4RHPd10s4KzeTnVr1c=
+golang.org/x/net v0.19.0/go.mod h1:CfAk/cbD4CthTvqiEl8NpboMuiuOYsAr/7NOjZJtv1U=
 golang.org/x/sys v0.0.0-20201015000850-e3ed0017c211/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.15.0 h1:h48lPFYpsTvQJZF4EKyI4aLHaev3CxivZmv7yZig9pc=
 golang.org/x/sys v0.15.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=


### PR DESCRIPTION
# What does this PR do?

Use publicsuffix to parse domain into root domain and sub domain.

Fixes #951.

# Motivation

#951

# Additional Notes

The [`publicsuffix.EffectiveTLDPlusOne`](https://pkg.go.dev/golang.org/x/net/publicsuffix#EffectiveTLDPlusOne) func does not work properly when the domain has a query string, so the domain is split.