### PR TITLE
opt IsPrivateNetwork func

### DIFF
--- a/util/net.go
+++ b/util/net.go
@@ -32,7 +32,10 @@ func IsPrivateNetwork(remoteAddr string) bool {
 	if remoteAddr == "localhost" {
 		return true
 	}
-
+	// private domain eg. .cluster.local
+	if strings.HasSuffix(remoteAddr, ".local") {
+		return true
+	}
 	return false
 }
 


### PR DESCRIPTION
for k8s .cluster.local

# What does this PR do?
Motivation
# Motivation
make it good
# Additional Notes
user always access with "http://ddns-go.default.svc.cluster.local:9876/"
it's private domain