### PR TITLE
feat(cloudflare): support `comment` param

### DIFF
--- a/dns/cloudflare.go
+++ b/dns/cloudflare.go
@@ -106,11 +106,10 @@ func (cf *Cloudflare) addUpdateDomainRecords(recordType string) {
 			return
 		}
 
-		params := domain.GetCustomParams()
 		// 存在参数才进行筛选
-		var commentParam string
-		if params.Has("comment") {
-			commentParam = fmt.Sprintf("&comment=%s", params.Get("comment"))
+		comment := domain.GetCustomParams().Get("comment")
+		if comment != "" {
+			comment = fmt.Sprintf("&comment=%s", comment)
 		}
 
 		zoneID := result.Result[0].ID
@@ -119,7 +118,7 @@ func (cf *Cloudflare) addUpdateDomainRecords(recordType string) {
 		// getDomains 最多更新前50条
 		err = cf.request(
 			"GET",
-			fmt.Sprintf(zonesAPI+"/%s/dns_records?type=%s&name=%s&per_page=50%s", zoneID, recordType, domain, commentParam),
+			fmt.Sprintf(zonesAPI+"/%s/dns_records?type=%s&name=%s&per_page=50%s", zoneID, recordType, domain, comment),
 			nil,
 			&records,
 		)

--- a/dns/cloudflare.go
+++ b/dns/cloudflare.go
@@ -154,9 +154,9 @@ func (cf *Cloudflare) create(zoneID string, domain *config.Domain, recordType st
 		Content: ipAddr,
 		Proxied: false,
 		TTL:     cf.TTL,
+		Comment: domain.GetCustomParams().Get("comment"),
 	}
 	record.Proxied = domain.GetCustomParams().Get("proxied") == "true"
-	record.Comment = domain.GetCustomParams().Get("comment")
 	var status CloudflareStatus
 	err := cf.request(
 		"POST",


### PR DESCRIPTION
# What does this PR do?
支持传递自定义参数`comment`来对 cloudflare 的 DNS 记录进行筛选，从而利用不同 comment 实现单域名多 IP 地址的效果

# Motivation
同#923，需要“单域名多 IP”的支持

# Additional Notes
- 当`comment`参数未指定时，行为和原先一致：忽略 DNS 记录的 comment，只匹配域名，且不会修改 comment
- 如果需要匹配无 comment 的记录，可以传入空串，例如`www:example.cn.eu.org?comment=`
- [API](https://developers.cloudflare.com/api/operations/dns-records-for-a-zone-list-dns-records) 其实还支持`.contains`等更高级的匹配模式，但对于“单域名多 IP”这一目标来说还用不到，因此暂未实现
