### PR TITLE
chore: remove unused params and unnecessary nil checks

### DIFF
--- a/dns/cloudflare.go
+++ b/dns/cloudflare.go
@@ -137,7 +137,7 @@ func (cf *Cloudflare) addUpdateDomainRecords(recordType string) {
 
 		if len(records.Result) > 0 {
 			// 更新
-			cf.modify(records, zoneID, domain, recordType, ipAddr)
+			cf.modify(records, zoneID, domain, ipAddr)
 		} else {
 			// 新增
 			cf.create(zoneID, domain, recordType, ipAddr)
@@ -180,7 +180,7 @@ func (cf *Cloudflare) create(zoneID string, domain *config.Domain, recordType st
 }
 
 // 修改
-func (cf *Cloudflare) modify(result CloudflareRecordsResp, zoneID string, domain *config.Domain, recordType string, ipAddr string) {
+func (cf *Cloudflare) modify(result CloudflareRecordsResp, zoneID string, domain *config.Domain, ipAddr string) {
 	for _, record := range result.Result {
 		// 相同不修改
 		if record.Content == ipAddr {
@@ -207,7 +207,7 @@ func (cf *Cloudflare) modify(result CloudflareRecordsResp, zoneID string, domain
 			return
 		}
 
-		if err == nil && status.Success {
+		if status.Success {
 			util.Log("更新域名解析 %s 成功! IP: %s", domain, ipAddr)
 			domain.UpdateStatus = config.UpdatedSuccess
 		} else {

--- a/dns/dnspod.go
+++ b/dns/dnspod.go
@@ -115,7 +115,7 @@ func (dnspod *Dnspod) create(domain *config.Domain, recordType string, ipAddr st
 		params.Set("record_line", "默认")
 	}
 
-	status, err := dnspod.commonRequest(recordCreateAPI, params, domain)
+	status, err := dnspod.request(recordCreateAPI, params)
 
 	if err != nil {
 		util.Log("新增域名解析 %s 失败! 异常信息: %s", domain, err)
@@ -123,7 +123,7 @@ func (dnspod *Dnspod) create(domain *config.Domain, recordType string, ipAddr st
 		return
 	}
 
-	if err == nil && status.Status.Code == "1" {
+	if status.Status.Code == "1" {
 		util.Log("新增域名解析 %s 成功! IP: %s", domain, ipAddr)
 		domain.UpdateStatus = config.UpdatedSuccess
 	} else {
@@ -155,7 +155,7 @@ func (dnspod *Dnspod) modify(record DnspodRecord, domain *config.Domain, recordT
 		params.Set("record_line", "默认")
 	}
 
-	status, err := dnspod.commonRequest(recordModifyURL, params, domain)
+	status, err := dnspod.request(recordModifyURL, params)
 
 	if err != nil {
 		util.Log("更新域名解析 %s 失败! 异常信息: %s", domain, err)
@@ -172,8 +172,8 @@ func (dnspod *Dnspod) modify(record DnspodRecord, domain *config.Domain, recordT
 	}
 }
 
-// 公共
-func (dnspod *Dnspod) commonRequest(apiAddr string, values url.Values, domain *config.Domain) (status DnspodStatus, err error) {
+// request sends a POST request to the given API with the given values.
+func (dnspod *Dnspod) request(apiAddr string, values url.Values) (status DnspodStatus, err error) {
 	client := util.CreateHTTPClient()
 	resp, err := client.PostForm(
 		apiAddr,

--- a/dns/google_domain.go
+++ b/dns/google_domain.go
@@ -65,12 +65,12 @@ func (gd *GoogleDomain) addUpdateDomainRecords(recordType string) {
 	}
 
 	for _, domain := range domains {
-		gd.modify(domain, recordType, ipAddr)
+		gd.modify(domain, ipAddr)
 	}
 }
 
 // 修改
-func (gd *GoogleDomain) modify(domain *config.Domain, recordType string, ipAddr string) {
+func (gd *GoogleDomain) modify(domain *config.Domain, ipAddr string) {
 	params := domain.GetCustomParams()
 	params.Set("hostname", domain.GetFullDomain())
 	params.Set("myip", ipAddr)

--- a/dns/huawei.go
+++ b/dns/huawei.go
@@ -103,7 +103,7 @@ func (hw *Huaweicloud) addUpdateDomainRecords(recordType string) {
 			// 名称相同才更新。华为云默认是模糊搜索
 			if record.Name == domain.String()+"." {
 				// 更新
-				hw.modify(record, domain, recordType, ipAddr)
+				hw.modify(record, domain, ipAddr)
 				find = true
 				break
 			}
@@ -170,7 +170,7 @@ func (hw *Huaweicloud) create(domain *config.Domain, recordType string, ipAddr s
 }
 
 // 修改
-func (hw *Huaweicloud) modify(record HuaweicloudRecordsets, domain *config.Domain, recordType string, ipAddr string) {
+func (hw *Huaweicloud) modify(record HuaweicloudRecordsets, domain *config.Domain, ipAddr string) {
 
 	// 相同不修改
 	if len(record.Records) > 0 && record.Records[0] == ipAddr {

--- a/dns/namecheap.go
+++ b/dns/namecheap.go
@@ -65,12 +65,12 @@ func (nc *NameCheap) addUpdateDomainRecords(recordType string) {
 	}
 
 	for _, domain := range domains {
-		nc.modify(domain, recordType, ipAddr)
+		nc.modify(domain, ipAddr)
 	}
 }
 
 // 修改
-func (nc *NameCheap) modify(domain *config.Domain, recordType string, ipAddr string) {
+func (nc *NameCheap) modify(domain *config.Domain, ipAddr string) {
 	var result NameCheapResp
 	err := nc.request(&result, ipAddr, domain)
 

--- a/util/update/detect.go
+++ b/util/update/detect.go
@@ -47,11 +47,9 @@ func findAssetForArch(arch string, rel *Release,
 	// 从 release 列表中查找最新的版本。
 	// GitHub API 返回的列表按照创建日期的顺序排列。
 	if a, v, ok := findAssetFromRelease(rel, getSuffixes(arch)); ok {
-		if release == nil || v.GreaterThan(version) {
-			version = v
-			asset = a
-			release = rel
-		}
+		version = v
+		asset = a
+		release = rel
 	}
 
 	if release == nil {

--- a/util/update/package.go
+++ b/util/update/package.go
@@ -58,7 +58,7 @@ func to(assetURL, assetFileName, cmdPath string) error {
 		return err
 	}
 	defer src.Close()
-	return decompressAndUpdate(src, assetFileName, assetURL, cmdPath)
+	return decompressAndUpdate(src, assetFileName, cmdPath)
 }
 
 func downloadAssetFromURL(url string) (rc io.ReadCloser, err error) {

--- a/util/update/update.go
+++ b/util/update/update.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 )
 
-func decompressAndUpdate(src io.Reader, assetName, assetURL, cmdPath string) error {
+func decompressAndUpdate(src io.Reader, assetName, cmdPath string) error {
 	_, cmd := filepath.Split(cmdPath)
 	asset, err := decompressCommand(src, assetName, cmd)
 	if err != nil {


### PR DESCRIPTION
# What does this PR do?

Remove unused params and unnecessary nil checks found by `gopls`.

# Motivation

These warnings are too noisy.

# Additional Notes

The `commonRequest` function in `Dnspod` was renamed to `request` because it was too long.

- https://pkg.go.dev/golang.org/x/tools/gopls/internal/analysis/unusedparams
- https://pkg.go.dev/golang.org/x/tools/go/analysis/passes/nilness