### PR TITLE
fix(goreleaser): add build for Android

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -12,12 +12,13 @@ builds:
     flags:
       - -trimpath
     goos:
+      - android
       - linux
       - windows
       - darwin
       - freebsd
     goarch:
-      - 386
+      - '386'
       - amd64
       - arm
       - arm64
@@ -26,16 +27,25 @@ builds:
       - mips64
       - mips64le
     goarm:
-      - 5
-      - 6
-      - 7
+      - '5'
+      - '6'
+      - '7'
     gomips:
       - hardfloat
       - softfloat
+    ignore:
+      # we only need the arm64 build on android
+      - goos: android
+        goarch: arm
+      - goos: android
+        goarch: '386'
+      - goos: android
+        goarch: amd64
+
     ldflags:
       - -s -w -X main.version={{.Tag}} -X main.buildTime={{.Date}}
 archives:
-    # use zip for windows archives
+  # use zip for windows archives
   - format_overrides:
       - goos: windows
         format: zip
@@ -52,7 +62,7 @@ archives:
 checksum:
   name_template: 'checksums.txt'
 snapshot:
-  name_template: "{{ .Tag }}-next"
+  name_template: '{{ .Tag }}-next'
 changelog:
   sort: asc
   filters:


### PR DESCRIPTION
# What does this PR do?

After revisiting the following issues, I finally realized that the `bad system call` bug on Termux should be fixed when GOOS is `android`. 

- golang/go#60125
- golang/go@58f6022eee95f43b4e0dc640b012bb3f574898f1

So, we just need to add a build for Android.

**Test passed on Termux.**

Fixes #1075.

# Motivation

#1075

# Additional Notes

- mattn/efm-langserver#268
- wormi4ok/evernote2md#109
- twpayne/chezmoi#3508
- #718