### PR TITLE
chore(dns): log only the root domain if not found in provider

### DIFF
--- a/dns/cloudflare.go
+++ b/dns/cloudflare.go
@@ -101,7 +101,7 @@ func (cf *Cloudflare) addUpdateDomainRecords(recordType string) {
 		}
 
 		if len(result.Result) == 0 {
-			util.Log("在DNS服务商中未找到域名: %s", domain.String())
+			util.Log("在DNS服务商中未找到根域名: %s", domain.DomainName)
 			domain.UpdateStatus = config.UpdatedFailed
 			return
 		}

--- a/dns/huawei.go
+++ b/dns/huawei.go
@@ -127,7 +127,7 @@ func (hw *Huaweicloud) create(domain *config.Domain, recordType string, ipAddr s
 	}
 
 	if len(zone.Zones) == 0 {
-		util.Log("在DNS服务商中未找到域名: %s", domain.String())
+		util.Log("在DNS服务商中未找到根域名: %s", domain.DomainName)
 		domain.UpdateStatus = config.UpdatedFailed
 		return
 	}

--- a/dns/porkbun.go
+++ b/dns/porkbun.go
@@ -99,7 +99,7 @@ func (pb *Porkbun) addUpdateDomainRecords(recordType string) {
 				pb.create(domain, recordType, ipAddr)
 			}
 		} else {
-			util.Log("在DNS服务商中未找到域名: %s", domain.String())
+			util.Log("在DNS服务商中未找到根域名: %s", domain.DomainName)
 			domain.UpdateStatus = config.UpdatedFailed
 		}
 	}

--- a/util/messages.go
+++ b/util/messages.go
@@ -37,7 +37,7 @@ func init() {
 	message.SetString(language.English, "通过接口获取IPv4失败! 接口地址: %s", "Get IPv4 from %s failed")
 	message.SetString(language.English, "通过接口获取IPv6失败! 接口地址: %s", "Get IPv6 from %s failed")
 	message.SetString(language.English, "将不会触发Webhook, 仅在第 3 次失败时触发一次Webhook, 当前失败次数：%d", "Webhook will not be triggered, only trigger once when the third failure, current failure times: %d")
-	message.SetString(language.English, "在DNS服务商中未找到域名: %s", "Domain %s not found in DNS provider")
+	message.SetString(language.English, "在DNS服务商中未找到根域名: %s", "Root domain not found in DNS provider: %s")
 
 	// webhook
 	message.SetString(language.English, "Webhook配置中的URL不正确", "Webhook url is incorrect")


### PR DESCRIPTION
# What does this PR do?

Logging only the root domain if the domain is not found in the DNS provider.

Useful when `publicsuffix` provides a wrong root domain.

# Motivation

- #1116 The log doesn't indicate which parts of the domain were used as a root domain.

# Additional Notes