### PR TITLE
fix: web godaddy url error

### DIFF
--- a/static/constant.js
+++ b/static/constant.js
@@ -98,7 +98,7 @@ const DNS_PROVIDERS = {
     idLabel: "Key",
     secretLabel: "Secret",
     helpHtml: {
-      "en": "<a target='_blank' href='https://porkbun.com/account/api'>Create API KEY</a>",
+      "en": "<a target='_blank' href='https://developer.godaddy.com/keys'>Create API KEY</a>",
       "zh-cn": "<a target='_blank' href='https://developer.godaddy.com/keys'>创建 API KEY</a>",
     }
   },


### PR DESCRIPTION
# What does this PR do?
fix web godaddy url error
web 界面-英文模式下，godaddy 的 create api key 的链接是 Porkbun

# Motivation

# Additional Notes
感谢作者的贡献，我另外发现godaddy最近修改api的使用权限，必须拥有50个域名的个人才可以调用域名相关api。
我没想好对此ddns-go需不需要做调整，如何做调整。上述 notes 供作者你参考。
