### PR TITLE
chore(GoReleaser): update config to version 2

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,8 @@
 # This is an example goreleaser.yaml file with some sane defaults.
 # Make sure to check the documentation at http://goreleaser.com
+
+version: 2
+
 before:
   hooks:
     # You may remove this if you don't use go modules.


### PR DESCRIPTION
# What does this PR do?

Update GoReleaser's config to version 2 in preparation for #1140.

Instructions at https://goreleaser.com/blog/goreleaser-v2/#upgrading have been followed.

# Motivation

- #1140

# Additional Notes

**No breaking changes during the upgrade process.** So we can just add the `version` header in the configuration file.