### PR TITLE
perf(params): use `NewReplacer` to replace params

### DIFF
--- a/config/webhook.go
+++ b/config/webhook.go
@@ -119,16 +119,15 @@ func getDomainsStatus(domains []*Domain) updateStatusType {
 }
 
 // replacePara 替换参数
-func replacePara(domains *Domains, orgPara string, ipv4Result updateStatusType, ipv6Result updateStatusType) (newPara string) {
-	orgPara = strings.ReplaceAll(orgPara, "#{ipv4Addr}", domains.Ipv4Addr)
-	orgPara = strings.ReplaceAll(orgPara, "#{ipv4Result}", util.LogStr(string(ipv4Result))) // i18n
-	orgPara = strings.ReplaceAll(orgPara, "#{ipv4Domains}", getDomainsStr(domains.Ipv4Domains))
-
-	orgPara = strings.ReplaceAll(orgPara, "#{ipv6Addr}", domains.Ipv6Addr)
-	orgPara = strings.ReplaceAll(orgPara, "#{ipv6Result}", util.LogStr(string(ipv6Result))) // i18n
-	orgPara = strings.ReplaceAll(orgPara, "#{ipv6Domains}", getDomainsStr(domains.Ipv6Domains))
-
-	return orgPara
+func replacePara(domains *Domains, orgPara string, ipv4Result updateStatusType, ipv6Result updateStatusType) string {
+	return strings.NewReplacer(
+		"#{ipv4Addr}", domains.Ipv4Addr,
+		"#{ipv4Result}", util.LogStr(string(ipv4Result)), // i18n
+		"#{ipv4Domains}", getDomainsStr(domains.Ipv4Domains),
+		"#{ipv6Addr}", domains.Ipv6Addr,
+		"#{ipv6Result}", util.LogStr(string(ipv6Result)), // i18n
+		"#{ipv6Domains}", getDomainsStr(domains.Ipv6Domains),
+	).Replace(orgPara)
 }
 
 // getDomainsStr 用逗号分割域名

--- a/dns/namecheap.go
+++ b/dns/namecheap.go
@@ -92,11 +92,12 @@ func (nc *NameCheap) modify(domain *config.Domain, ipAddr string) {
 
 // request 统一请求接口
 func (nc *NameCheap) request(result *NameCheapResp, ipAddr string, domain *config.Domain) (err error) {
-	var url string = nameCheapEndpoint
-	url = strings.ReplaceAll(url, "#{host}", domain.GetSubDomain())
-	url = strings.ReplaceAll(url, "#{domain}", domain.DomainName)
-	url = strings.ReplaceAll(url, "#{password}", nc.DNS.Secret)
-	url = strings.ReplaceAll(url, "#{ip}", ipAddr)
+	url := strings.NewReplacer(
+		"#{host}", domain.GetSubDomain(),
+		"#{domain}", domain.DomainName,
+		"#{password}", nc.DNS.Secret,
+		"#{ip}", ipAddr,
+	).Replace(nameCheapEndpoint)
 
 	req, err := http.NewRequest(
 		http.MethodGet,


### PR DESCRIPTION
# What does this PR do?

Changed all `ReplaceAll()` to `NewReplacer()` to improve performance when replacing parameters.

# Motivation

Compared to `ReplaceAll()`, `NewReplacer()` is probably a better choice, because you only need to maintain a list of old and new string pairs.

# Additional Notes

Use a map to build parameters in callback to improve readability.

Also fixed `this value of err is never used (SA4006)` in `NameSilo.listRecords` by error handling.

---

- https://pkg.go.dev/strings#NewReplacer