### PR TITLE
fix(cloudflare): convert DNS record names to Punycode

### DIFF
--- a/config/domains.go
+++ b/config/domains.go
@@ -74,14 +74,14 @@ func (d Domain) GetCustomParams() url.Values {
 	return url.Values{}
 }
 
-// ToASCII converts the name of [Domain] to its ASCII form,
+// ToASCII converts [Domain] to its ASCII form,
 // using non-transitional process specified in UTS 46.
 //
 // Note: conversion errors are silently discarded and partial conversion
 // results are used.
-func (d Domain) ToASCII() *Domain {
-	d.DomainName, _ = nontransitionalLookup.ToASCII(d.DomainName)
-	return &d
+func (d Domain) ToASCII() string {
+	name, _ := nontransitionalLookup.ToASCII(d.String())
+	return name
 }
 
 // GetNewIp 接口/网卡/命令获得 ip 并校验用户输入的域名

--- a/config/domains.go
+++ b/config/domains.go
@@ -74,13 +74,14 @@ func (d Domain) GetCustomParams() url.Values {
 	return url.Values{}
 }
 
-// ASCII converts the name of [Domain] to its ASCII form,
+// ToASCII converts the name of [Domain] to its ASCII form,
 // using non-transitional process specified in UTS 46.
 //
 // Note: conversion errors are silently discarded and partial conversion
 // results are used.
-func (d *Domain) ASCII() {
+func (d Domain) ToASCII() *Domain {
 	d.DomainName, _ = nontransitionalLookup.ToASCII(d.DomainName)
+	return &d
 }
 
 // GetNewIp 接口/网卡/命令获得 ip 并校验用户输入的域名

--- a/config/domains.go
+++ b/config/domains.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/jeessy2/ddns-go/v6/util"
+	"golang.org/x/net/idna"
 	"golang.org/x/net/publicsuffix"
 )
 
@@ -27,6 +28,16 @@ type Domain struct {
 	CustomParams string
 	UpdateStatus updateStatusType // 更新状态
 }
+
+// nontransitionalLookup implements the nontransitional processing as specified in
+// Unicode Technical Standard 46 with almost all checkings off to maximize user freedom.
+//
+// Copied from: https://github.com/cloudflare/cloudflare-go/blob/v0.97.0/dns.go#L95
+var nontransitionalLookup = idna.New(
+	idna.MapForLookup(),
+	idna.StrictDomainName(false),
+	idna.ValidateLabels(false),
+)
 
 func (d Domain) String() string {
 	if d.SubDomain != "" {
@@ -61,6 +72,15 @@ func (d Domain) GetCustomParams() url.Values {
 		}
 	}
 	return url.Values{}
+}
+
+// ASCII converts the name of [Domain] to its ASCII form,
+// using non-transitional process specified in UTS 46.
+//
+// Note: conversion errors are silently discarded and partial conversion
+// results are used.
+func (d *Domain) ASCII() {
+	d.DomainName, _ = nontransitionalLookup.ToASCII(d.DomainName)
 }
 
 // GetNewIp 接口/网卡/命令获得 ip 并校验用户输入的域名

--- a/config/domains_test.go
+++ b/config/domains_test.go
@@ -42,8 +42,9 @@ func TestToASCII(t *testing.T) {
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
 			d := &Domain{DomainName: tt.domain}
-			if d.ToASCII().DomainName != tt.expected {
-				t.Errorf("ToASCII() = %v, want %v", d.DomainName, tt.expected)
+			actual := d.ToASCII()
+			if actual != tt.expected {
+				t.Errorf("ToASCII() = %v, want %v", actual, tt.expected)
 			}
 		})
 	}

--- a/config/domains_test.go
+++ b/config/domains_test.go
@@ -2,10 +2,10 @@ package config
 
 import "testing"
 
-// TestASCII test converts [Domain] to its ASCII form.
+// TestToASCII test converts the name of [Domain] to its ASCII form.
 //
 // Copied from: https://github.com/cloudflare/cloudflare-go/blob/v0.97.0/dns_test.go#L15
-func TestASCII(t *testing.T) {
+func TestToASCII(t *testing.T) {
 	tests := map[string]struct {
 		domain   string
 		expected string
@@ -42,8 +42,7 @@ func TestASCII(t *testing.T) {
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
 			d := &Domain{DomainName: tt.domain}
-			d.ASCII()
-			if d.DomainName != tt.expected {
+			if d.ToASCII().DomainName != tt.expected {
 				t.Errorf("ToASCII() = %v, want %v", d.DomainName, tt.expected)
 			}
 		})

--- a/config/domains_test.go
+++ b/config/domains_test.go
@@ -1,8 +1,54 @@
 package config
 
-import (
-	"testing"
-)
+import "testing"
+
+// TestASCII test converts [Domain] to its ASCII form.
+//
+// Copied from: https://github.com/cloudflare/cloudflare-go/blob/v0.97.0/dns_test.go#L15
+func TestASCII(t *testing.T) {
+	tests := map[string]struct {
+		domain   string
+		expected string
+	}{
+		"empty": {
+			"", "",
+		},
+		"unicode get encoded": {
+			"😺.com", "xn--138h.com",
+		},
+		"unicode gets mapped and encoded": {
+			"ÖBB.at", "xn--bb-eka.at",
+		},
+		"punycode stays punycode": {
+			"xn--138h.com", "xn--138h.com",
+		},
+		"hyphens are not checked": {
+			"s3--s4.com", "s3--s4.com",
+		},
+		"STD3 rules are not enforced": {
+			"℀.com", "a/c.com",
+		},
+		"bidi check is disabled": {
+			"englishﻋﺮﺑﻲ.com", "xn--english-gqjzfwd1j.com",
+		},
+		"invalid joiners are allowed": {
+			"a\u200cb.com", "xn--ab-j1t.com",
+		},
+		"partial results are used despite errors": {
+			"xn--:D.xn--.😺.com", "xn--:d..xn--138h.com",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			d := &Domain{DomainName: tt.domain}
+			d.ASCII()
+			if d.DomainName != tt.expected {
+				t.Errorf("ToASCII() = %v, want %v", d.DomainName, tt.expected)
+			}
+		})
+	}
+}
 
 // TestParseDomainArr 测试 parseDomainArr
 func TestParseDomainArr(t *testing.T) {

--- a/dns/cloudflare.go
+++ b/dns/cloudflare.go
@@ -13,10 +13,7 @@ import (
 	"github.com/jeessy2/ddns-go/v6/util"
 )
 
-const (
-	zonesAPI = "https://api.cloudflare.com/client/v4/zones"
-	pageSize = "50"
-)
+const zonesAPI = "https://api.cloudflare.com/client/v4/zones"
 
 // Cloudflare Cloudflare实现
 type Cloudflare struct {
@@ -114,7 +111,7 @@ func (cf *Cloudflare) addUpdateDomainRecords(recordType string) {
 		//
 		// See: cloudflare/cloudflare-go#690
 		params.Set("name", domain.ToASCII().String())
-		params.Set("per_page", pageSize)
+		params.Set("per_page", "50")
 		// Add a comment only if it exists
 		if c := domain.GetCustomParams().Get("comment"); c != "" {
 			params.Set("comment", c)
@@ -230,7 +227,7 @@ func (cf *Cloudflare) getZones(domain *config.Domain) (result CloudflareZonesRes
 	params := url.Values{}
 	params.Set("name", domain.DomainName)
 	params.Set("status", "active")
-	params.Set("per_page", pageSize)
+	params.Set("per_page", "50")
 
 	err = cf.request(
 		"GET",

--- a/dns/cloudflare.go
+++ b/dns/cloudflare.go
@@ -110,7 +110,7 @@ func (cf *Cloudflare) addUpdateDomainRecords(recordType string) {
 		// The name of DNS records in Cloudflare API expects Punycode.
 		//
 		// See: cloudflare/cloudflare-go#690
-		params.Set("name", domain.ToASCII().String())
+		params.Set("name", domain.ToASCII())
 		params.Set("per_page", "50")
 		// Add a comment only if it exists
 		if c := domain.GetCustomParams().Get("comment"); c != "" {
@@ -154,7 +154,7 @@ func (cf *Cloudflare) addUpdateDomainRecords(recordType string) {
 func (cf *Cloudflare) create(zoneID string, domain *config.Domain, recordType string, ipAddr string) {
 	record := &CloudflareRecord{
 		Type:    recordType,
-		Name:    domain.ToASCII().String(),
+		Name:    domain.ToASCII(),
 		Content: ipAddr,
 		Proxied: false,
 		TTL:     cf.TTL,

--- a/dns/cloudflare.go
+++ b/dns/cloudflare.go
@@ -108,14 +108,12 @@ func (cf *Cloudflare) addUpdateDomainRecords(recordType string) {
 			return
 		}
 
-		// The name of DNS records in Cloudflare API expects Punycode.
-		//
-		// See: cloudflare/cloudflare-go#688
-		domain.ASCII()
-
 		params := url.Values{}
 		params.Set("type", recordType)
-		params.Set("name", domain.String())
+		// The name of DNS records in Cloudflare API expects Punycode.
+		//
+		// See: cloudflare/cloudflare-go#690
+		params.Set("name", domain.ToASCII().String())
 		params.Set("per_page", pageSize)
 		// Add a comment only if it exists
 		if c := domain.GetCustomParams().Get("comment"); c != "" {
@@ -159,7 +157,7 @@ func (cf *Cloudflare) addUpdateDomainRecords(recordType string) {
 func (cf *Cloudflare) create(zoneID string, domain *config.Domain, recordType string, ipAddr string) {
 	record := &CloudflareRecord{
 		Type:    recordType,
-		Name:    domain.String(),
+		Name:    domain.ToASCII().String(),
 		Content: ipAddr,
 		Proxied: false,
 		TTL:     cf.TTL,


### PR DESCRIPTION
# What does this PR do?

Converts DNS record names to its Punycode format with package [`golang.org/x/net/idna`](https://pkg.go.dev/golang.org/x/net/idna).

Cloudflare API still has trouble handling Unicode forms of IDNs.

# Motivation

- #661
- #1159

# Additional Notes

- cloudflare/cloudflare-go#688
- cloudflare/cloudflare-go#690

---

Also use [`url.Values`](https://pkg.go.dev/net/url#Values) to build the URL parameters for GET requests.