### PR TITLE
feat: add DNS-over-TCP support to customize DNS servers

### DIFF
--- a/util/net_resolver.go
+++ b/util/net_resolver.go
@@ -27,22 +27,17 @@ func InitBackupDNS(customDNS, lang string) {
 // SetDNS sets the dialer.Resolver to use the given DNS server.
 func SetDNS(dns string) {
 
+	if !strings.Contains(dns, "://") {
+		dns = "udp://" + dns
+	}
 	svrParse, _ := url.Parse(dns)
 
 	var network string
 	switch strings.ToLower(svrParse.Scheme) {
 	case "tcp":
 		network = "tcp"
-	case "udp":
-		network = "udp"
 	default:
 		network = "udp"
-	}
-
-	// An empty scheme meams that given DNS doesn't have the scheme.
-	// And Host is parsed to Path.
-	if svrParse.Scheme == "" && svrParse.Host == "" {
-		svrParse.Host = svrParse.Path
 	}
 
 	if svrParse.Port() == "" {

--- a/util/net_resolver.go
+++ b/util/net_resolver.go
@@ -43,7 +43,7 @@ func SetDNS(dns string) {
 	if svrParse.Port() == "" {
 		dns = net.JoinHostPort(svrParse.Host, "53")
 	} else {
-		dns = net.JoinHostPort(svrParse.Host, svrParse.Port())
+		dns = svrParse.Host
 	}
 
 	dialer.Resolver = &net.Resolver{


### PR DESCRIPTION
# What does this PR do?
为 custom DNS Servers 添加 DNS-over-TCP 查询支持

# Motivation
避免传统 53/udp 端口不可用的情况

# Additional Notes
1、不添加`udp://`、`tcp://`协议前缀的情况下，默认使用 UDP 协议
2、不添加`:53`端口结构的情况下，默认使用 53 端口