### PR TITLE
Allow web access from CGNAT ips

### DIFF
--- a/util/net.go
+++ b/util/net.go
@@ -34,7 +34,6 @@ func IsPrivateNetwork(remoteAddr string) bool {
 		return ip.IsLoopback() || // 127/8, ::1
 			ip.IsPrivate() || // 10/8, 172.16/12, 192.168/16, fc00::/7
 			ip.IsLinkLocalUnicast() || // 169.254/16, fe80::/10
-			ip.IsLinkLocalMulticast() || // ff00::/8
 			IsCGNATReserved(&ip) // 100.64/10
 	}
 

--- a/util/net.go
+++ b/util/net.go
@@ -6,11 +6,9 @@ import (
 	"strings"
 )
 
+var _, CGNATReserved, _ = net.ParseCIDR("100.64.0.0/10")
+
 func IsCGNATReserved(ip *net.IP) bool {
-	_, CGNATReserved, err := net.ParseCIDR("100.64.0.0/10")
-	if err != nil {
-		return false
-	}
 	return CGNATReserved.Contains(*ip)
 }
 

--- a/util/net.go
+++ b/util/net.go
@@ -6,6 +6,14 @@ import (
 	"strings"
 )
 
+func IsCGNATReserved(ip *net.IP) bool {
+	_, CGNATReserved, err := net.ParseCIDR("100.64.0.0/10")
+	if err != nil {
+		return false
+	}
+	return CGNATReserved.Contains(*ip)
+}
+
 // IsPrivateNetwork 是否为私有地址
 // https://en.wikipedia.org/wiki/Private_network
 func IsPrivateNetwork(remoteAddr string) bool {
@@ -25,7 +33,9 @@ func IsPrivateNetwork(remoteAddr string) bool {
 	if ip := net.ParseIP(remoteAddr); ip != nil {
 		return ip.IsLoopback() || // 127/8, ::1
 			ip.IsPrivate() || // 10/8, 172.16/12, 192.168/16, fc00::/7
-			ip.IsLinkLocalUnicast() // 169.254/16, fe80::/10
+			ip.IsLinkLocalUnicast() || // 169.254/16, fe80::/10
+			ip.IsLinkLocalMulticast() || // ff00::/8
+			IsCGNATReserved(&ip) // 100.64/10
 	}
 
 	return false

--- a/util/net_test.go
+++ b/util/net_test.go
@@ -18,6 +18,8 @@ func TestIsPrivateNetwork(t *testing.T) {
 		"10.1.1.18:9876":    true,
 		"[fe80::1]:9876":    true,
 		"[fd00::1]:9876":    true,
+		"100.64.0.1:9876":   true,
+		"100.114.5.14:9876": true,
 		"100.0.0.1":         false,
 		"100.0.0.1:9876":    false,
 		"[2409::1]":         false,


### PR DESCRIPTION
# What does this PR do?

Enable web admin page access from CGNAT reserved IPs (`100.64.0.0/10`), primarily for cooperating with Tailscale.

允许 CGNAT 段 IP 访问网页管理端，主要目的是支持通过 Tailscale 使用。

# Motivation

As described above, enable direct access to web admin page via Tailscale tunnels.

Tailscale 本身支持端对端加密，但我用 Tailscale 访问管理管理端直接被拒绝了…… 所以开一个 PR 增加 CGNAT 段支持。

# Additional Notes
