### PR TITLE
fix: 安卓环境Go Time 固定UTC时区，通过时区获取偏移量修正时区

### DIFF
--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"time"
 
@@ -56,6 +57,9 @@ var customDNS = flag.String("dns", "", "Custom DNS server address, example: 8.8.
 // 重置密码
 var newPassword = flag.String("resetPassword", "", "Reset password to the one entered")
 
+// 修正安卓时区
+var timeZone = flag.String("tZ", "Asia/Shanghai", "fix Android Time Zone")
+
 //go:embed static
 var staticEmbeddedFiles embed.FS
 
@@ -74,6 +78,15 @@ func main() {
 	if *updateFlag {
 		update.Self(version)
 		return
+	}
+
+	// 安卓 go/src/time/zoneinfo_android.go 固定localLoc 为 UTC
+	//	func initLocal() {
+	//		// TODO(elias.naur): getprop persist.sys.timezone
+	//		localLoc = *UTC
+	//	}
+	if runtime.GOOS == "android" {
+		util.FixTimezone(*timeZone)
 	}
 	// 检查监听地址
 	if _, err := net.ResolveTCPAddr("tcp", *listen); err != nil {

--- a/main.go
+++ b/main.go
@@ -57,9 +57,6 @@ var customDNS = flag.String("dns", "", "Custom DNS server address, example: 8.8.
 // 重置密码
 var newPassword = flag.String("resetPassword", "", "Reset password to the one entered")
 
-// 修正安卓时区
-var timeZone = flag.String("tZ", "Asia/Shanghai", "fix Android Time Zone")
-
 //go:embed static
 var staticEmbeddedFiles embed.FS
 
@@ -81,12 +78,8 @@ func main() {
 	}
 
 	// 安卓 go/src/time/zoneinfo_android.go 固定localLoc 为 UTC
-	//	func initLocal() {
-	//		// TODO(elias.naur): getprop persist.sys.timezone
-	//		localLoc = *UTC
-	//	}
 	if runtime.GOOS == "android" {
-		util.FixTimezone(*timeZone)
+		util.FixTimezone()
 	}
 	// 检查监听地址
 	if _, err := net.ResolveTCPAddr("tcp", *listen); err != nil {

--- a/util/andriod_time.go
+++ b/util/andriod_time.go
@@ -1,34 +1,19 @@
 package util
 
-import "time"
+import (
+	"os/exec"
+	"strings"
+	"time"
+)
 
-func FixTimezone(timeZoneStr string) {
-	offset, err := getTimeZoneOffset(timeZoneStr)
-
-	// 如果解析不出来, 不修改时区
+func FixTimezone() {
+	out, err := exec.Command("/system/bin/getprop", "persist.sys.timezone").Output()
 	if err != nil {
 		return
 	}
-
-	timeZone := time.FixedZone("GMT", offset*3600)
-	time.Local = timeZone
-}
-
-// 将时区字符串转换为偏移量（以小时为单位）
-func getTimeZoneOffset(timeZoneStr string) (int, error) {
-	// 获取时区信息
-	location, err := time.LoadLocation(timeZoneStr)
+	timeZone, err := time.LoadLocation(strings.TrimSpace(string(out)))
 	if err != nil {
-		return 0, err
+		return
 	}
-
-	// 获取当前时间
-	currentTime := time.Now().In(location)
-
-	_, offsetInSeconds := currentTime.Zone()
-
-	// 将秒转换为小时
-	offsetInHours := offsetInSeconds / 3600
-
-	return offsetInHours, nil
+	time.Local = timeZone
 }

--- a/util/andriod_time.go
+++ b/util/andriod_time.go
@@ -1,0 +1,34 @@
+package util
+
+import "time"
+
+func FixTimezone(timeZoneStr string) {
+	offset, err := getTimeZoneOffset(timeZoneStr)
+
+	// 如果解析不出来, 不修改时区
+	if err != nil {
+		return
+	}
+
+	timeZone := time.FixedZone("GMT", offset*3600)
+	time.Local = timeZone
+}
+
+// 将时区字符串转换为偏移量（以小时为单位）
+func getTimeZoneOffset(timeZoneStr string) (int, error) {
+	// 获取时区信息
+	location, err := time.LoadLocation(timeZoneStr)
+	if err != nil {
+		return 0, err
+	}
+
+	// 获取当前时间
+	currentTime := time.Now().In(location)
+
+	_, offsetInSeconds := currentTime.Zone()
+
+	// 将秒转换为小时
+	offsetInHours := offsetInSeconds / 3600
+
+	return offsetInHours, nil
+}


### PR DESCRIPTION
修复安卓环境运行ddns-go 少8小时的问题。

[go/src/time/zoneinfo_android.go]
func initLocal() {
	// TODO(elias.naur): getprop persist.sys.timezone
	localLoc = *UTC
}

zoneinfo_android.go 固定了 localLoc 为 UTC，所以设置环境变量无效。
设置启动参数 tZ, 默认从环境获取时区字符串, 判断当前GOOS为 android 调用 FixTimezone 进行时区修正