### PR TITLE
fix: use current system proxy config instead of boot config

### DIFF
--- a/util/http_client_util.go
+++ b/util/http_client_util.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"net"
 	"net/http"
+	"net/url"
 	"time"
 )
 
@@ -15,7 +16,7 @@ var dialer = &net.Dialer{
 
 var defaultTransport = &http.Transport{
 	// from http.DefaultTransport
-	Proxy: func(req *http.Request) (*net.URL, error) {
+	Proxy: func(req *http.Request) (*url.URL, error) {
         return http.ProxyFromEnvironment(req)
     },
 	DialContext: func(ctx context.Context, network, address string) (net.Conn, error) {

--- a/util/http_client_util.go
+++ b/util/http_client_util.go
@@ -15,7 +15,9 @@ var dialer = &net.Dialer{
 
 var defaultTransport = &http.Transport{
 	// from http.DefaultTransport
-	Proxy: http.ProxyFromEnvironment,
+	Proxy: func(req *http.Request) (*net.URL, error) {
+        return http.ProxyFromEnvironment(req)
+    },
 	DialContext: func(ctx context.Context, network, address string) (net.Conn, error) {
 		return dialer.DialContext(ctx, network, address)
 	},


### PR DESCRIPTION
# What does this PR do?
 使用发起请求时的系统代理配置，而不是应用启动时的系统代理配置。

# Motivation
原来的问题：
在 Go 语言中，使用 http.ProxyFromEnvironment 的 HTTP 客户端会读取环境变量（如 HTTP_PROXY 和 HTTPS_PROXY）来设置代理，但环境变量的读取是在 HTTP 客户端初始化的时候进行的。因此，客户端初始化后，再设置这些环境变量并不会影响已经创建的客户端的代理设置。如果你的应用是在启动后才设置 HTTPS_PROXY 环境变量，那么之前创建的 HTTP 客户端实例不会使用新的代理配置。

解决：
每次请求前读取最新的 HTTPS_PROXY 变量并动态设置代理，在 Transport 的 Proxy 字段中直接使用一个自定义的函数来动态读取环境变量。这样每次请求时都会动态调用 http.ProxyFromEnvironment，以使用当前的代理配置环境变量。

# Additional Notes
