### PR TITLE
fix: escape URL path to prevent issues with unescaped characters when use webhook

### DIFF
--- a/config/webhook.go
+++ b/config/webhook.go
@@ -74,7 +74,7 @@ func ExecWebhook(domains *Domains, conf *Config) (v4Status updateStatusType, v6S
 			util.Log("Webhook配置中的URL不正确")
 			return
 		}
-		req, err := http.NewRequest(method, fmt.Sprintf("%s://%s%s?%s", u.Scheme, u.Host, u.Path, u.Query().Encode()), strings.NewReader(postPara))
+		req, err := http.NewRequest(method, fmt.Sprintf("%s://%s%s?%s", u.Scheme, u.Host, u.EscapedPath(), u.Query().Encode()), strings.NewReader(postPara))
 		if err != nil {
 			util.Log("Webhook调用失败! 异常信息：%s", err)
 			return


### PR DESCRIPTION
# What does this PR do?

This PR fixes an issue with the URL path not being properly escaped when constructing an HTTP request. It updates the code to use u.EscapedPath() instead of u.Path to ensure that special characters in the URL path are correctly escaped.

# Motivation

I want to add a newline character (%0A) to the URL path. In the current implementation (master branch), there is a hacky workaround that uses %250A (where %0A would be expected) to achieve this. This behavior is incorrect and caused by the lack of proper escaping for the path. By switching to u.EscapedPath(), newline characters and other special characters are correctly encoded, eliminating the need for double-encoding workarounds.

# Additional Notes

None