### PR TITLE
feat: update golang version to 1.23

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jeessy2/ddns-go/v6
 
-go 1.20
+go 1.23
 
 require (
 	github.com/kardianos/service v1.2.2


### PR DESCRIPTION
# What does this PR do?
update golang version to 1.23, No longer supports older system, such as win 7

# Motivation

# Additional Notes
