### PR TITLE
feat: No longer pushing to homebrew

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,27 +54,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-
-  homebrew:
-    needs: goreleaser
-    runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/homebrew/ubuntu22.04:master
-    steps:
-      - name: Set up Homebrew
-        uses: Homebrew/actions/setup-homebrew@master
-        with:
-          test-bot: false
-
-      - name: Configure Git user
-        uses: Homebrew/actions/git-user-config@master
-
-      - name: Tap formulae repo
-        run: brew tap ivaquero/chinese
-
-      - name: Bump formulae
-        uses: Homebrew/actions/bump-formulae@master
-        with:
-          # Custom GitHub access token with only the 'workflow' scope enabled
-          token: ${{ secrets.HOMEBREW_COMMITTER_TOKEN }}
-          formulae: ddns-go

--- a/README.md
+++ b/README.md
@@ -66,11 +66,6 @@
     ./ddns-go -resetPassword 123456
     ./ddns-go -resetPassword 123456 -c /Users/name/.ddns_go_config.yaml
     ```
-- [可选] 使用 [Homebrew](https://brew.sh) 安装 [ddns-go](https://formulae.brew.sh/formula/ddns-go)：
-
-  ```bash
-  brew install ddns-go
-  ```
 
 ## Docker中使用
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -63,11 +63,6 @@ Automatically obtain your public IPv4 or IPv6 address and resolve it to the corr
     ```bash
     ./ddns-go -resetPassword 123456
     ```
-- [Optional] You can use [Homebrew](https://brew.sh) to install [ddns-go](https://formulae.brew.sh/formula/ddns-go)
-
-  ```bash
-  brew install ddns-go
-  ```
 
 ## Use in docker
 


### PR DESCRIPTION
# What does this PR do?
Few people use homebrew to install ddns-go, so we will stop pushing updates to Homebrew to reduce maintenance workload

# Motivation

# Additional Notes
