### PR TITLE
feat(huaweicloud): 添加单动态多静态IP地址DDNS支持

### DIFF
--- a/config/domains.go
+++ b/config/domains.go
@@ -11,12 +11,14 @@ import (
 
 // Domains Ipv4/Ipv6 domains
 type Domains struct {
-	Ipv4Addr    string
-	Ipv4Cache   *util.IpCache
-	Ipv4Domains []*Domain
-	Ipv6Addr    string
-	Ipv6Cache   *util.IpCache
-	Ipv6Domains []*Domain
+	Ipv4Addr           string
+	Ipv4Cache          *util.IpCache
+	Ipv4DnsRecordCount int
+	Ipv4Domains        []*Domain
+	Ipv6Addr           string
+	Ipv6DnsRecordCount int
+	Ipv6Cache          *util.IpCache
+	Ipv6Domains        []*Domain
 }
 
 // Domain 域名实体


### PR DESCRIPTION
# What does this PR do?

- 添加单动态多静态IP地址DDNS支持

# Motivation

主要为了保留用户预设的固定的内网IP地址  
计算机可能随时处于双栈或者单栈接入
此举意在让双栈组网工具依然可以正常地提供双栈访问  
同时可以覆盖以下场景  

1. 公网IP地址时有时无
2. DHCP分配的IP地址时有时无

# Additional Notes
