### PR TITLE
fix(traffic_route): 通过精确获取DNS记录解决找不到历史记录的问题， fix #1495

### DIFF
--- a/dns/traffic_route.go
+++ b/dns/traffic_route.go
@@ -107,7 +107,14 @@ func (tr *TrafficRoute) addUpdateDomainRecords(recordType string) {
 		tr.request(
 			"GET",
 			"ListRecords",
-			map[string][]string{"ZID": {strconv.Itoa(zoneID)}},
+			map[string][]string{
+				"ZID":        {strconv.Itoa(zoneID)},
+				"Type":       {recordType},
+				"Host":       {domain.GetSubDomain()},
+				"SearchMode": {"exact"},
+				"PageNumber": {"1"},
+				"PageSize":   {"500"},
+			},
 			&recordResp,
 		)
 


### PR DESCRIPTION
# What does this PR do?

修复火山引擎在DNS多的时候无法获取解析记录，导致一直在创建 DNS 记录

# Motivation

使用过程遇到了 Bug

# Additional Notes
