### PR TITLE
新增 -noserve 参数支持，允许跳过系统服务逻辑，以兼容某些嵌入式设备

### DIFF
--- a/main.go
+++ b/main.go
@@ -48,6 +48,9 @@ var configFilePath = flag.String("c", util.GetConfigFilePathDefault(), "Custom c
 // Web 服务
 var noWebService = flag.Bool("noweb", false, "No web service")
 
+// 不运行系统服务
+var noServe = flag.Bool("noserve", false, "Do not run as system service")
+
 // 跳过验证证书
 var skipVerify = flag.Bool("skipVerify", false, "Skip certificate verification")
 
@@ -119,7 +122,8 @@ func main() {
 	case "restart":
 		restartService()
 	default:
-		if util.IsRunInDocker() {
+		// 在Docker中运行或明确指定noserve参数时，直接运行
+		if util.IsRunInDocker() || *noServe {
 			run()
 		} else {
 			s := getService()


### PR DESCRIPTION
1. 添加 -noserve 命令行参数，当启用时：
   - 强制直接运行程序逻辑（run()）
   - 跳过服务安装检查和服务托管流程
   - 行为模式与Docker运行模式保持一致

2. 修改主逻辑判断条件：
   - 原 docker 判断条件扩展为 `util.IsRunInDocker() || *noServe`
   - 显式声明非服务化运行意图时采用相同处理逻辑

3. 参数说明：
   - 适用于需要直接控制进程的场景
   - 避免与系统服务管理器（systemd等）产生交互
   - 保留完整的DDNS核心功能

使用示例：
./ddns-go -noserve -l :8080
（以非服务模式直接运行并监听8080端口）

关联影响说明：
不影响现有服务管理功能（-s install/uninstall/restart）
与 -noweb 参数形成互补（一个控制Web服务，一个控制进程托管）
参数默认值保持 false 确保向后兼容

# What does this PR do?

# Motivation

# Additional Notes
