### PR TITLE
fix: use u.String() to build request URL instead of manual concatenation (#1559)

### DIFF
--- a/config/webhook.go
+++ b/config/webhook.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"net/url"
 	"strings"
@@ -74,7 +73,7 @@ func ExecWebhook(domains *Domains, conf *Config) (v4Status updateStatusType, v6S
 			util.Log("Webhook配置中的URL不正确")
 			return
 		}
-		req, err := http.NewRequest(method, fmt.Sprintf("%s://%s%s?%s", u.Scheme, u.Host, u.EscapedPath(), u.Query().Encode()), strings.NewReader(postPara))
+		req, err := http.NewRequest(method, u.String(), strings.NewReader(postPara))
 		if err != nil {
 			util.Log("Webhook调用失败! 异常信息：%s", err)
 			return


### PR DESCRIPTION
- # What does this PR do?
When the request path does not have parameters, the request will carry a "?", resulting in service verification failure.  #1559
