### PR TITLE
feat: add daemon mode for background execution

### DIFF
--- a/util/osutil/daemon_unix.go
+++ b/util/osutil/daemon_unix.go
@@ -1,0 +1,18 @@
+//go:build !windows
+
+package osutil
+
+import (
+	"os"
+	"syscall"
+)
+
+// StartDetachedProcess starts a process detached from terminal on Unix-like systems.
+func StartDetachedProcess(exe string, args []string, nullFile *os.File) (*os.Process, error) {
+	attr := &os.ProcAttr{
+		Env:   append(os.Environ(), "DDNS_GO_DAEMON=1"),
+		Files: []*os.File{nullFile, nullFile, nullFile},
+		Sys:   &syscall.SysProcAttr{Setsid: true},
+	}
+	return os.StartProcess(exe, args, attr)
+}

--- a/util/osutil/daemon_win32.go
+++ b/util/osutil/daemon_win32.go
@@ -1,0 +1,25 @@
+//go:build windows
+
+package osutil
+
+import (
+	"os"
+	"syscall"
+)
+
+// StartDetachedProcess starts a process detached from console on Windows.
+func StartDetachedProcess(exe string, args []string, nullFile *os.File) (*os.Process, error) {
+	const (
+		DETACHED_PROCESS         = 0x00000008
+		CREATE_NEW_PROCESS_GROUP = 0x00000200
+		CREATE_NO_WINDOW         = 0x08000000
+	)
+
+	attr := &os.ProcAttr{
+		Env:   append(os.Environ(), "DDNS_GO_DAEMON=1"),
+		Files: []*os.File{nullFile, nullFile, nullFile},
+		Sys:   &syscall.SysProcAttr{CreationFlags: DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW, HideWindow: true},
+	}
+
+	return os.StartProcess(exe, args, attr)
+}


### PR DESCRIPTION
# What does this PR do?
新加一个-d 参数，用于将程序变成后台进程，以脱离终端
# Motivation
我将程序移植到我的路由器中时候，发现路由器中的系统并非标准的linux发行版，无法自启动成为后台程序

# Additional Notes
我测试了linux下的x86和arm64以及windows下的x86都是ok的