### PR TITLE
feat: add Team ID support for Vercel DNS configuration

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -55,8 +55,8 @@ type DNS struct {
 	Name   string
 	ID     string
 	Secret string
-	// TeamId 可选参数，用于某些DNS提供商（如Vercel）
-	TeamId string
+	// ExtParam 扩展参数，用于某些DNS提供商的特殊需求（如Vercel的teamId）
+	ExtParam string
 }
 
 type Config struct {

--- a/dns/vercel.go
+++ b/dns/vercel.go
@@ -150,12 +150,12 @@ func (v *Vercel) request(method, api string, data, result interface{}) (err erro
 		payload, _ = json.Marshal(data)
 	}
 
-	// 如果设置了 TeamId，添加查询参数
-	if v.DNS.TeamId != "" {
+	// 如果设置了 ExtParam (TeamId)，添加查询参数
+	if v.DNS.ExtParam != "" {
 		if strings.Contains(api, "?") {
-			api = api + "&teamId=" + v.DNS.TeamId
+			api = api + "&teamId=" + v.DNS.ExtParam
 		} else {
-			api = api + "?teamId=" + v.DNS.TeamId
+			api = api + "?teamId=" + v.DNS.ExtParam
 		}
 	}
 

--- a/static/constant.js
+++ b/static/constant.js
@@ -133,6 +133,11 @@ const DNS_PROVIDERS = {
     helpHtml: {
       "en": "<a target='_blank' href='https://vercel.com/account/tokens'>Create Token</a>",
       "zh-cn": "<a target='_blank' href='https://vercel.com/account/tokens'>创建令牌</a>",
+    },
+    extParamLabel: "Team ID",
+    extParamHelpHtml: {
+      "en": "Optional. If you are using a Vercel Team account, please fill in the Team ID",
+      "zh-cn": "可选项，如果您使用的是 Vercel 团队账户，请填写团队 ID"
     }
   },
   dynadot: {

--- a/static/i18n.js
+++ b/static/i18n.js
@@ -234,7 +234,7 @@ const I18N_MAP = {
     'en': 'Switch between light and dark themes',
     'zh-cn': '切换明暗主题'
   },
-  "teamIdHelp": {
+  "extParamHelp": {
     'en': 'Optional. If you are using a Vercel Team account, please fill in the Team ID',
     'zh-cn': '可选项，如果您使用的是 Vercel 团队账户，请填写团队 ID'
   },

--- a/web/save.go
+++ b/web/save.go
@@ -81,7 +81,7 @@ func checkAndSave(request *http.Request) string {
 		dnsConf.DNS.Name = v.DnsName
 		dnsConf.DNS.ID = strings.TrimSpace(v.DnsID)
 		dnsConf.DNS.Secret = strings.TrimSpace(v.DnsSecret)
-		dnsConf.DNS.TeamId = strings.TrimSpace(v.DnsTeamId)
+		dnsConf.DNS.ExtParam = strings.TrimSpace(v.DnsExtParam)
 
 		if v.Ipv4Domains == "" && v.Ipv6Domains == "" {
 			util.Log("第 %s 个配置未填写域名", util.Ordinal(k+1, conf.Lang))

--- a/web/writing.go
+++ b/web/writing.go
@@ -23,7 +23,7 @@ type dnsConf4JS struct {
 	DnsName          string
 	DnsID            string
 	DnsSecret        string
-	DnsTeamId        string
+	DnsExtParam      string
 	TTL              string
 	Ipv4Enable       bool
 	Ipv4GetType      string
@@ -90,7 +90,7 @@ func getDnsConfStr(dnsConf []config.DnsConfig) string {
 			DnsName:          conf.DNS.Name,
 			DnsID:            idHide,
 			DnsSecret:        secretHide,
-			DnsTeamId:        conf.DNS.TeamId,
+			DnsExtParam:      conf.DNS.ExtParam,
 			TTL:              conf.TTL,
 			Ipv4Enable:       conf.Ipv4.Enable,
 			Ipv4GetType:      conf.Ipv4.GetType,

--- a/web/writing.html
+++ b/web/writing.html
@@ -158,21 +158,22 @@
                   </div>
                 </div>
 
-                <div class="form-group row" id="DnsTeamIdRow" style="display: none;">
+                <div class="form-group row" id="DnsExtParamRow" style="display: none;">
                   <label
-                    for="DnsTeamId"
+                    for="DnsExtParam"
+                    id="dnsExtParamLabel"
                     class="col-sm-2 col-form-label"
                     >Team ID</label
                   >
                   <div class="col-sm-10">
                     <input
                       class="form-control form"
-                      name="DnsTeamId"
-                      id="DnsTeamId"
+                      name="DnsExtParam"
+                      id="DnsExtParam"
                       placeholder="team_xxxxxx (可选)"
                     />
                     <small class="form-text text-muted">
-                      <span data-i18n-html="teamIdHelp">
+                      <span id="dnsExtParamHelp" data-i18n-html="extParamHelp">
                         可选项，如果您使用的是 Vercel 团队账户，请填写团队 ID
                       </span>
                     </small>
@@ -761,7 +762,7 @@
       DnsID: "",
       DnsName: "alidns",
       DnsSecret: "",
-      DnsTeamId: "",
+      DnsExtParam: "",
       Ipv4Cmd: "",
       Ipv4Domains: "",
       Ipv4Enable: true,
@@ -811,18 +812,22 @@
       $input.addEventListener('click', e => {
         const dnsInfo = DNS_PROVIDERS[e.target.value];
         const $dnsID = document.getElementById("DnsID");
-        const $dnsTeamIdRow = document.getElementById("DnsTeamIdRow");
+        const $dnsExtParamRow = document.getElementById("DnsExtParamRow");
+        const $dnsExtParamLabel = document.getElementById("dnsExtParamLabel");
+        const $dnsExtParamHelp = document.getElementById("dnsExtParamHelp");
         // idLabel 为空时隐藏 DnsID
         if (dnsInfo.idLabel) {
           $dnsID.style.display = "block";
         } else {
           $dnsID.style.display = "none";
         }
-        // 只有 Vercel 时显示 TeamId
-        if (e.target.value === "vercel") {
-          $dnsTeamIdRow.style.display = "";
+        // 根据DNS提供商显示扩展参数
+        if (dnsInfo.extParamLabel) {
+          $dnsExtParamRow.style.display = "";
+          $dnsExtParamLabel.innerHTML = dnsInfo.extParamLabel;
+          $dnsExtParamHelp.innerHTML = i18n(dnsInfo.extParamHelpHtml);
         } else {
-          $dnsTeamIdRow.style.display = "none";
+          $dnsExtParamRow.style.display = "none";
         }
         document.getElementById("dnsIdLabel").innerHTML = dnsInfo.idLabel;
         document.getElementById("dnsSecretLabel").innerHTML = dnsInfo.secretLabel;
@@ -924,12 +929,17 @@
             break;
         }
       }
-      // 根据 DNS 提供商显示或隐藏 TeamId 输入框
-      const $dnsTeamIdRow = document.getElementById("DnsTeamIdRow");
-      if (conf.DnsName === "vercel") {
-        $dnsTeamIdRow.style.display = "";
+      // 根据 DNS 提供商显示或隐藏扩展参数输入框
+      const $dnsExtParamRow = document.getElementById("DnsExtParamRow");
+      const $dnsExtParamLabel = document.getElementById("dnsExtParamLabel");
+      const $dnsExtParamHelp = document.getElementById("dnsExtParamHelp");
+      const dnsInfo = DNS_PROVIDERS[conf.DnsName];
+      if (dnsInfo && dnsInfo.extParamLabel) {
+        $dnsExtParamRow.style.display = "";
+        $dnsExtParamLabel.innerHTML = dnsInfo.extParamLabel;
+        $dnsExtParamHelp.innerHTML = i18n(dnsInfo.extParamHelpHtml);
       } else {
-        $dnsTeamIdRow.style.display = "none";
+        $dnsExtParamRow.style.display = "none";
       }
     }
 


### PR DESCRIPTION
# What does this PR do?
This update introduces a new optional `TeamId` field in the DNS configuration, allowing users to specify their Vercel Team ID. The Team ID is included in API requests when applicable. Additionally, the UI has been updated to show the Team ID input field only when the Vercel DNS provider is selected, along with relevant help text for users.

Changes include:
- Added `TeamId` field to DNS struct in config.go.
- Updated Vercel API request handling to include Team ID.
- Modified frontend to conditionally display Team ID input based on selected DNS provider.
- Added localization support for Team ID help text.

Additionally, when the user selects GoDaddy, remind them that GoDaddy’s API has usage limitations.
# Motivation
Make the provider Vercel available.  
Give better reminders.
# Additional Notes
none