### PR TITLE
feat: add color-scheme support for better dark theme detection

### DIFF
--- a/static/common.css
+++ b/static/common.css
@@ -1,9 +1,11 @@
 :root {
+    color-scheme: light dark;
     --bg-color: #f2f3f8;
     --text-color: black;
 }
 
 [data-theme="dark"] {
+    color-scheme: dark;
     --bg-color: #22272e;
     --text-color: #adbac7;
 }

--- a/static/theme.js
+++ b/static/theme.js
@@ -1,10 +1,14 @@
 function toggleTheme(write = false) {
   const docEle = document.documentElement;
+  const metaTag = document.getElementById("color-scheme-meta");
+
   if (docEle.getAttribute("data-theme") === "dark") {
     docEle.removeAttribute("data-theme");
+    if (metaTag) metaTag.setAttribute("content", "light dark");
     write && localStorage.setItem("theme", "light");
   } else {
     docEle.setAttribute("data-theme", "dark");
+    if (metaTag) metaTag.setAttribute("content", "dark light");
     write && localStorage.setItem("theme", "dark");
   }
 }

--- a/web/login.html
+++ b/web/login.html
@@ -5,6 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="author" content="jeessy2" />
+    <meta name="color-scheme" content="light dark" id="color-scheme-meta" />
     <title>DDNS-GO</title>
     <link
       class="theme"

--- a/web/writing.html
+++ b/web/writing.html
@@ -5,6 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="author" content="jeessy2" />
+    <meta name="color-scheme" content="light dark" id="color-scheme-meta" />
     <title>DDNS-GO</title>
     <link
       class="theme"


### PR DESCRIPTION
# What does this PR do?

为 Web 界面添加 color-scheme meta 标签和 CSS 属性，用于正确声明网站的暗色主题支持。

# Motivation

color-scheme 是一个 Web 标准属性，用于告诉浏览器和工具网站原生支持暗色模式。如果没有这个声明，浏览器无法判断网站是否自己处理了暗色模式，可能会导致一些问题：

- 浏览器默认 UI 元素（滚动条、表单控件等）无法匹配网站主题
- 暗色模式扩展（例如 DarkReader）和工具可能无法识别网站的原生实现

添加这个声明可以改善浏览器集成，提升与暗色模式工具的兼容性。

# Additional Notes

修改内容：
- 在 writing.html 和 login.html 中添加 color-scheme meta 标签
- 在 common.css 的 :root 和 [data-theme="dark"] 中添加 color-scheme 属性
- 更新 toggleTheme() 函数，在主题切换时同步更新 meta 标签

此修改已在 Chrome 和 Firefox 下测试通过，DarkReader 等暗色主题扩展可以正确检测到网站的原生暗色模式并自动避让，不再出现重复应用滤镜的问题。

参考资料：
- https://web.dev/color-scheme/
- https://developer.mozilla.org/docs/Web/CSS/color-scheme