### PR TITLE
Add per-config HTTP interface binding (curl --interface equivalent)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"io"
 	"log"
+	"net/http"
 	"os"
 	"os/exec"
 	"regexp"
@@ -47,6 +48,8 @@ type DnsConfig struct {
 	}
 	DNS DNS
 	TTL string
+	// 发送HTTP请求时使用的网卡名称，为空则使用默认网卡
+	HttpInterface string
 }
 
 // DNS DNS配置
@@ -418,4 +421,9 @@ func (conf *DnsConfig) GetIpv6Addr() (result string) {
 		log.Println("IPv6's get IP method is unknown")
 		return "" // unknown type
 	}
+}
+
+// GetHTTPClient 获得HTTP客户端，如果配置了HttpInterface则绑定到指定网卡
+func (conf *DnsConfig) GetHTTPClient() *http.Client {
+	return util.CreateHTTPClientWithInterface(conf.HttpInterface)
 }

--- a/dns/alidns.go
+++ b/dns/alidns.go
@@ -16,9 +16,10 @@ const (
 // https://help.aliyun.com/document_detail/29776.html?spm=a2c4g.11186623.6.672.715a45caji9dMA
 // Alidns Alidns
 type Alidns struct {
-	DNS     config.DNS
-	Domains config.Domains
-	TTL     string
+	DNS        config.DNS
+	Domains    config.Domains
+	TTL        string
+	httpClient *http.Client
 }
 
 // AlidnsRecord record
@@ -54,6 +55,7 @@ func (ali *Alidns) Init(dnsConf *config.DnsConfig, ipv4cache *util.IpCache, ipv6
 	} else {
 		ali.TTL = dnsConf.TTL
 	}
+	ali.httpClient = dnsConf.GetHTTPClient()
 }
 
 // AddUpdateDomainRecords 添加或更新IPv4/IPv6记录
@@ -185,7 +187,7 @@ func (ali *Alidns) request(params url.Values, result interface{}) (err error) {
 		return
 	}
 
-	client := util.CreateHTTPClient()
+	client := ali.httpClient
 	resp, err := client.Do(req)
 	err = util.GetHTTPResponse(resp, err, result)
 

--- a/dns/aliesa.go
+++ b/dns/aliesa.go
@@ -24,6 +24,7 @@ type Aliesa struct {
 
 	siteCache   map[string]AliesaSite
 	domainCache config.DomainTuples
+	httpClient  *http.Client
 }
 
 // AliesaSiteResp 站点返回结果
@@ -73,6 +74,7 @@ func (ali *Aliesa) Init(dnsConf *config.DnsConfig, ipv4cache *util.IpCache, ipv6
 	} else {
 		ali.TTL = dnsConf.TTL
 	}
+	ali.httpClient = dnsConf.GetHTTPClient()
 }
 
 // AddUpdateDomainRecords 添加或更新IPv4/IPv6记录
@@ -383,7 +385,7 @@ func (ali *Aliesa) request(method string, params url.Values, result interface{})
 		return
 	}
 
-	client := util.CreateHTTPClient()
+	client := ali.httpClient
 	resp, err := client.Do(req)
 	err = util.GetHTTPResponse(resp, err, result)
 

--- a/dns/baidu.go
+++ b/dns/baidu.go
@@ -17,9 +17,10 @@ const (
 )
 
 type BaiduCloud struct {
-	DNS     config.DNS
-	Domains config.Domains
-	TTL     int
+	DNS        config.DNS
+	Domains    config.Domains
+	TTL        int
+	httpClient *http.Client
 }
 
 // BaiduRecord 单条解析记录
@@ -83,6 +84,7 @@ func (baidu *BaiduCloud) Init(dnsConf *config.DnsConfig, ipv4cache *util.IpCache
 			baidu.TTL = ttl
 		}
 	}
+	baidu.httpClient = dnsConf.GetHTTPClient()
 }
 
 // AddUpdateDomainRecords 添加或更新IPv4/IPv6记录
@@ -198,7 +200,7 @@ func (baidu *BaiduCloud) request(method string, url string, data interface{}, re
 
 	util.BaiduSigner(baidu.DNS.ID, baidu.DNS.Secret, req)
 
-	client := util.CreateHTTPClient()
+	client := baidu.httpClient
 	resp, err := client.Do(req)
 	err = util.GetHTTPResponse(resp, err, result)
 

--- a/dns/callback.go
+++ b/dns/callback.go
@@ -12,11 +12,12 @@ import (
 )
 
 type Callback struct {
-	DNS      config.DNS
-	Domains  config.Domains
-	TTL      string
-	lastIpv4 string
-	lastIpv6 string
+	DNS        config.DNS
+	Domains    config.Domains
+	TTL        string
+	lastIpv4   string
+	lastIpv6   string
+	httpClient *http.Client
 }
 
 // Init 初始化
@@ -34,6 +35,7 @@ func (cb *Callback) Init(dnsConf *config.DnsConfig, ipv4cache *util.IpCache, ipv
 	} else {
 		cb.TTL = dnsConf.TTL
 	}
+	cb.httpClient = dnsConf.GetHTTPClient()
 }
 
 // AddUpdateDomainRecords 添加或更新IPv4/IPv6记录

--- a/dns/cloudflare.go
+++ b/dns/cloudflare.go
@@ -17,9 +17,10 @@ const zonesAPI = "https://api.cloudflare.com/client/v4/zones"
 
 // Cloudflare Cloudflare实现
 type Cloudflare struct {
-	DNS     config.DNS
-	Domains config.Domains
-	TTL     int
+	DNS        config.DNS
+	Domains    config.Domains
+	TTL        int
+	httpClient *http.Client
 }
 
 // CloudflareZonesResp cloudflare zones返回结果
@@ -73,6 +74,7 @@ func (cf *Cloudflare) Init(dnsConf *config.DnsConfig, ipv4cache *util.IpCache, i
 			cf.TTL = ttl
 		}
 	}
+	cf.httpClient = dnsConf.GetHTTPClient()
 }
 
 // AddUpdateDomainRecords 添加或更新IPv4/IPv6记录
@@ -256,7 +258,7 @@ func (cf *Cloudflare) request(method string, url string, data interface{}, resul
 	req.Header.Set("Authorization", "Bearer "+cf.DNS.Secret)
 	req.Header.Set("Content-Type", "application/json")
 
-	client := util.CreateHTTPClient()
+	client := cf.httpClient
 	resp, err := client.Do(req)
 	err = util.GetHTTPResponse(resp, err, result)
 

--- a/dns/dnsla.go
+++ b/dns/dnsla.go
@@ -20,9 +20,10 @@ const (
 // https://www.dns.la/docs/ApiDoc
 // dnsla dnsla实现
 type Dnsla struct {
-	DNS     config.DNS
-	Domains config.Domains
-	TTL     int
+	DNS        config.DNS
+	Domains    config.Domains
+	TTL        int
+	httpClient *http.Client
 }
 
 // DnslaRecord
@@ -65,6 +66,7 @@ func (dnsla *Dnsla) Init(dnsConf *config.DnsConfig, ipv4cache *util.IpCache, ipv
 		ttlInt, _ := strconv.Atoi(dnsConf.TTL)
 		dnsla.TTL = ttlInt
 	}
+	dnsla.httpClient = dnsConf.GetHTTPClient()
 }
 
 // AddUpdateDomainRecords 添加或更新IPv4/IPv6记录
@@ -218,7 +220,7 @@ func (dnsla *Dnsla) request(method, apiAddr string, values []byte) (body []byte,
 	req.Header.Set("Authorization", token)
 	req.Header.Set("Content-Type", "application/json;charset=utf-8")
 	// 4. 发送请求
-	client := &http.Client{}
+	client := dnsla.httpClient
 	resp, err := client.Do(req)
 	if err != nil {
 		panic(err)
@@ -254,7 +256,7 @@ func (dnsla *Dnsla) getRecordList(domain *config.Domain, typ string) (result []b
 	req.Header.Set("Authorization", token)
 
 	// 发送请求
-	client := &http.Client{}
+	client := dnsla.httpClient
 	resp, err := client.Do(req)
 	if err != nil {
 		panic(err)

--- a/dns/dynadot.go
+++ b/dns/dynadot.go
@@ -17,11 +17,12 @@ const (
 
 // Dynadot Dynadot
 type Dynadot struct {
-	DNS      config.DNS
-	Domains  config.Domains
-	TTL      string
-	LastIpv4 string
-	LastIpv6 string
+	DNS        config.DNS
+	Domains    config.Domains
+	TTL        string
+	LastIpv4   string
+	LastIpv6   string
+	httpClient *http.Client
 }
 
 // DynadotRecord record
@@ -54,6 +55,7 @@ func (dynadot *Dynadot) Init(dnsConf *config.DnsConfig, ipv4cache *util.IpCache,
 	} else {
 		dynadot.TTL = dnsConf.TTL
 	}
+	dynadot.httpClient = dnsConf.GetHTTPClient()
 }
 
 // AddUpdateDomainRecords 添加或更新IPv4/IPv6记录
@@ -178,7 +180,7 @@ func (dynadot *Dynadot) request(params url.Values, result interface{}) (err erro
 		return
 	}
 
-	client := util.CreateHTTPClient()
+	client := dynadot.httpClient
 	resp, err := client.Do(req)
 	err = util.GetHTTPResponse(resp, err, result)
 

--- a/dns/dynv6.go
+++ b/dns/dynv6.go
@@ -15,9 +15,10 @@ const (
 )
 
 type Dynv6 struct {
-	DNS     config.DNS
-	Domains config.Domains
-	TTL     string
+	DNS        config.DNS
+	Domains    config.Domains
+	TTL        string
+	httpClient *http.Client
 }
 
 type Dynv6Zone struct {
@@ -47,6 +48,7 @@ func (dynv6 *Dynv6) Init(dnsConf *config.DnsConfig, ipv4cache *util.IpCache, ipv
 	} else {
 		dynv6.TTL = dnsConf.TTL
 	}
+	dynv6.httpClient = dnsConf.GetHTTPClient()
 }
 
 // AddUpdateDomainRecords 添加或更新IPv4/IPv6记录
@@ -266,7 +268,7 @@ func (dynv6 *Dynv6) request(method string, url string, data interface{}, result 
 	req.Header.Add("Authorization", "Bearer "+dynv6.DNS.Secret)
 	req.Header.Set("Content-Type", "application/json")
 
-	client := util.CreateHTTPClient()
+	client := dynv6.httpClient
 	resp, err := client.Do(req)
 	err = util.GetHTTPResponse(resp, err, result)
 	return err

--- a/dns/edgeone.go
+++ b/dns/edgeone.go
@@ -18,9 +18,10 @@ const (
 )
 
 type EdgeOne struct {
-	DNS     config.DNS
-	Domains config.Domains
-	TTL     int
+	DNS        config.DNS
+	Domains    config.Domains
+	TTL        int
+	httpClient *http.Client
 }
 
 type EdgeOneRecord struct {
@@ -91,6 +92,7 @@ func (eo *EdgeOne) Init(dnsConf *config.DnsConfig, ipv4cache *util.IpCache, ipv6
 			eo.TTL = ttl
 		}
 	}
+	eo.httpClient = dnsConf.GetHTTPClient()
 }
 
 // AddUpdateDomainRecords 添加或更新 IPv4/IPv6 记录
@@ -300,7 +302,7 @@ func (eo *EdgeOne) request(action string, data interface{}, result interface{}) 
 
 	util.TencentCloudSigner(eo.DNS.ID, eo.DNS.Secret, req, action, string(jsonStr), util.EdgeOne)
 
-	client := util.CreateHTTPClient()
+	client := eo.httpClient
 	resp, err := client.Do(req)
 	err = util.GetHTTPResponse(resp, err, result)
 

--- a/dns/eranet.go
+++ b/dns/eranet.go
@@ -20,9 +20,10 @@ import (
 
 // Eranet DNS实现
 type Eranet struct {
-	DNS     config.DNS
-	Domains config.Domains
-	TTL     string
+	DNS        config.DNS
+	Domains    config.Domains
+	TTL        string
+	httpClient *http.Client
 }
 
 type EranetRecord struct {
@@ -59,6 +60,7 @@ func (eranet *Eranet) Init(dnsConf *config.DnsConfig, ipv4cache *util.IpCache, i
 	} else {
 		eranet.TTL = dnsConf.TTL
 	}
+	eranet.httpClient = dnsConf.GetHTTPClient()
 }
 
 // AddUpdateDomainRecords 添加或更新IPv4/IPv6记录
@@ -264,9 +266,7 @@ func (t *Eranet) request(apiPath string, params map[string]string, method string
 	req.Header.Set("Accept", "application/json")
 
 	// 发送请求
-	client := &http.Client{
-		Timeout: 30 * time.Second,
-	}
+	client := t.httpClient
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("请求失败: %v", err)

--- a/dns/gcore.go
+++ b/dns/gcore.go
@@ -16,9 +16,10 @@ const gcoreAPIEndpoint = "https://api.gcore.com/dns/v2"
 
 // Gcore Gcore DNS实现
 type Gcore struct {
-	DNS     config.DNS
-	Domains config.Domains
-	TTL     int
+	DNS        config.DNS
+	Domains    config.Domains
+	TTL        int
+	httpClient *http.Client
 }
 
 // GcoreZoneResponse zones返回结果
@@ -87,6 +88,7 @@ func (gc *Gcore) Init(dnsConf *config.DnsConfig, ipv4cache *util.IpCache, ipv6ca
 			gc.TTL = ttl
 		}
 	}
+	gc.httpClient = dnsConf.GetHTTPClient()
 }
 
 // AddUpdateDomainRecords 添加或更新 IPv4 / IPv6 记录
@@ -293,7 +295,7 @@ func (gc *Gcore) request(method string, url string, data interface{}, result int
 	req.Header.Set("Authorization", "APIKey "+gc.DNS.Secret)
 	req.Header.Set("Content-Type", "application/json")
 
-	client := util.CreateHTTPClient()
+	client := gc.httpClient
 	resp, err := client.Do(req)
 	err = util.GetHTTPResponse(resp, err, result)
 

--- a/dns/godaddy.go
+++ b/dns/godaddy.go
@@ -47,7 +47,7 @@ func (g *GoDaddyDNS) Init(dnsConf *config.DnsConfig, ipv4cache *util.IpCache, ip
 		"Content-Type":  {"application/json"},
 	}
 
-	g.client = util.CreateHTTPClient()
+	g.client = dnsConf.GetHTTPClient()
 }
 
 func (g *GoDaddyDNS) updateDomainRecord(recordType string, ipAddr string, domains []*config.Domain) {

--- a/dns/huawei.go
+++ b/dns/huawei.go
@@ -19,9 +19,10 @@ const (
 // https://support.huaweicloud.com/api-dns/dns_api_64001.html
 // Huaweicloud Huaweicloud
 type Huaweicloud struct {
-	DNS     config.DNS
-	Domains config.Domains
-	TTL     int
+	DNS        config.DNS
+	Domains    config.Domains
+	TTL        int
+	httpClient *http.Client
 }
 
 // HuaweicloudZonesResp zones response
@@ -67,6 +68,7 @@ func (hw *Huaweicloud) Init(dnsConf *config.DnsConfig, ipv4cache *util.IpCache, 
 			hw.TTL = ttl
 		}
 	}
+	hw.httpClient = dnsConf.GetHTTPClient()
 }
 
 // AddUpdateDomainRecords 添加或更新IPv4/IPv6记录
@@ -305,7 +307,7 @@ func (hw *Huaweicloud) request(method string, urlString string, data interface{}
 
 	req.Header.Add("content-type", "application/json")
 
-	client := util.CreateHTTPClient()
+	client := hw.httpClient
 	resp, err := client.Do(req)
 	err = util.GetHTTPResponse(resp, err, result)
 

--- a/dns/name_com.go
+++ b/dns/name_com.go
@@ -20,9 +20,10 @@ const (
 )
 
 type NameCom struct {
-	DNS     config.DNS
-	Domains config.Domains
-	TTL     string
+	DNS        config.DNS
+	Domains    config.Domains
+	TTL        string
+	httpClient *http.Client
 }
 
 type NameComRecord struct {
@@ -62,6 +63,7 @@ func (n *NameCom) Init(dnsConf *config.DnsConfig, ipv4cache *util.IpCache, ipv6c
 	} else {
 		n.TTL = dnsConf.TTL
 	}
+	n.httpClient = dnsConf.GetHTTPClient()
 }
 
 func (n *NameCom) AddUpdateDomainRecords() (domains config.Domains) {
@@ -177,7 +179,7 @@ func (n *NameCom) request(action string, url string, data any, result any) (err 
 		req.Header.Add("Content-Type", "application/json")
 	}
 
-	client := util.CreateHTTPClient()
+	client := n.httpClient
 	resp, err := client.Do(req)
 	err = util.GetHTTPResponse(resp, err, result)
 

--- a/dns/namecheap.go
+++ b/dns/namecheap.go
@@ -15,10 +15,11 @@ const (
 
 // NameCheap Domain
 type NameCheap struct {
-	DNS      config.DNS
-	Domains  config.Domains
-	lastIpv4 string
-	lastIpv6 string
+	DNS        config.DNS
+	Domains    config.Domains
+	lastIpv4   string
+	lastIpv6   string
+	httpClient *http.Client
 }
 
 // NameCheap 修改域名解析结果
@@ -36,6 +37,7 @@ func (nc *NameCheap) Init(dnsConf *config.DnsConfig, ipv4cache *util.IpCache, ip
 
 	nc.DNS = dnsConf.DNS
 	nc.Domains.GetNewIp(dnsConf)
+	nc.httpClient = dnsConf.GetHTTPClient()
 }
 
 // AddUpdateDomainRecords 添加或更新IPv4/IPv6记录
@@ -109,7 +111,7 @@ func (nc *NameCheap) request(result *NameCheapResp, ipAddr string, domain *confi
 		return
 	}
 
-	client := util.CreateHTTPClient()
+	client := nc.httpClient
 	resp, err := client.Do(req)
 	if err != nil {
 		return

--- a/dns/namesilo.go
+++ b/dns/namesilo.go
@@ -18,10 +18,11 @@ const (
 
 // NameSilo Domain
 type NameSilo struct {
-	DNS      config.DNS
-	Domains  config.Domains
-	lastIpv4 string
-	lastIpv6 string
+	DNS        config.DNS
+	Domains    config.Domains
+	lastIpv4   string
+	lastIpv6   string
+	httpClient *http.Client
 }
 
 // NameSiloResp 修改域名解析结果
@@ -72,6 +73,7 @@ func (ns *NameSilo) Init(dnsConf *config.DnsConfig, ipv4cache *util.IpCache, ipv
 
 	ns.DNS = dnsConf.DNS
 	ns.Domains.GetNewIp(dnsConf)
+	ns.httpClient = dnsConf.GetHTTPClient()
 }
 
 // AddUpdateDomainRecords 添加或更新IPv4/IPv6记录
@@ -180,7 +182,7 @@ func (ns *NameSilo) request(ipAddr string, domain *config.Domain, recordID, reco
 		return
 	}
 
-	client := util.CreateHTTPClient()
+	client := ns.httpClient
 	resp, err := client.Do(req)
 	if err != nil {
 		return

--- a/dns/nowcn.go
+++ b/dns/nowcn.go
@@ -20,9 +20,10 @@ import (
 // https://www.todaynic.com/docApi/
 // Nowcn nowcn DNS实现
 type Nowcn struct {
-	DNS     config.DNS
-	Domains config.Domains
-	TTL     string
+	DNS        config.DNS
+	Domains    config.Domains
+	TTL        string
+	httpClient *http.Client
 }
 
 // NowcnRecord DNS记录结构
@@ -62,6 +63,7 @@ func (nowcn *Nowcn) Init(dnsConf *config.DnsConfig, ipv4cache *util.IpCache, ipv
 	} else {
 		nowcn.TTL = dnsConf.TTL
 	}
+	nowcn.httpClient = dnsConf.GetHTTPClient()
 }
 
 // AddUpdateDomainRecords 添加或更新IPv4/IPv6记录
@@ -253,9 +255,7 @@ func (t *Nowcn) request(apiPath string, params map[string]string, method string)
 	req.Header.Set("Accept", "application/json")
 
 	// 发送请求
-	client := &http.Client{
-		Timeout: 30 * time.Second,
-	}
+	client := t.httpClient
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("请求失败: %v", err)

--- a/dns/nsone.go
+++ b/dns/nsone.go
@@ -15,9 +15,10 @@ import (
 const nsoneAPIEndpoint = "https://api.nsone.net/v1/zones"
 
 type NSOne struct {
-	DNS     config.DNS
-	Domains config.Domains
-	TTL     int
+	DNS        config.DNS
+	Domains    config.Domains
+	TTL        int
+	httpClient *http.Client
 }
 
 type NSOneZone struct {
@@ -189,6 +190,7 @@ func (nsone *NSOne) Init(dnsConf *config.DnsConfig, ipv4cache *util.IpCache, ipv
 			nsone.TTL = ttl
 		}
 	}
+	nsone.httpClient = dnsConf.GetHTTPClient()
 }
 
 func (nsone *NSOne) AddUpdateDomainRecords() config.Domains {
@@ -364,7 +366,7 @@ func (nsone *NSOne) request(method string, url string, data interface{}, result 
 	req.Header.Set("X-NSONE-Key", nsone.DNS.Secret)
 	req.Header.Set("Content-Type", "application/json")
 
-	client := util.CreateHTTPClient()
+	client := nsone.httpClient
 	resp, err := client.Do(req)
 	err = util.GetHTTPResponse(resp, err, result)
 

--- a/dns/porkbun.go
+++ b/dns/porkbun.go
@@ -15,9 +15,10 @@ const (
 )
 
 type Porkbun struct {
-	DNSConfig config.DNS
-	Domains   config.Domains
-	TTL       string
+	DNSConfig  config.DNS
+	Domains    config.Domains
+	TTL        string
+	httpClient *http.Client
 }
 type PorkbunDomainRecord struct {
 	Name    *string `json:"name"`    // subdomain
@@ -57,6 +58,7 @@ func (pb *Porkbun) Init(conf *config.DnsConfig, ipv4cache *util.IpCache, ipv6cac
 	} else {
 		pb.TTL = conf.TTL
 	}
+	pb.httpClient = conf.GetHTTPClient()
 }
 
 // AddUpdateDomainRecords 添加或更新IPv4/IPv6记录
@@ -198,7 +200,7 @@ func (pb *Porkbun) request(url string, data interface{}, result interface{}) (er
 	}
 	req.Header.Set("Content-Type", "application/json")
 
-	client := util.CreateHTTPClient()
+	client := pb.httpClient
 	resp, err := client.Do(req)
 	err = util.GetHTTPResponse(resp, err, result)
 

--- a/dns/spaceship.go
+++ b/dns/spaceship.go
@@ -17,9 +17,10 @@ const spaceshipAPI = "https://spaceship.dev/api/v1/dns/records"
 const maxRecords = 500
 
 type Spaceship struct {
-	domains config.Domains
-	header  http.Header
-	ttl     int
+	domains    config.Domains
+	header     http.Header
+	ttl        int
+	httpClient *http.Client
 }
 
 func (s *Spaceship) Init(dnsConf *config.DnsConfig, ipv4cache *util.IpCache, ipv6cache *util.IpCache) {
@@ -36,6 +37,7 @@ func (s *Spaceship) Init(dnsConf *config.DnsConfig, ipv4cache *util.IpCache, ipv
 		"X-API-Secret": {dnsConf.DNS.Secret},
 		"Content-Type": {"application/json"},
 	}
+	s.httpClient = dnsConf.GetHTTPClient()
 }
 
 func (s *Spaceship) AddUpdateDomainRecords() (domains config.Domains) {
@@ -71,7 +73,7 @@ func (s *Spaceship) request(domain *config.Domain, method string, query url.Valu
 	req.Header = s.header
 	req.URL.RawQuery = query.Encode()
 
-	cli := util.CreateHTTPClient()
+	cli := s.httpClient
 	resp, err := cli.Do(req)
 	if err != nil {
 		return

--- a/dns/tencent_cloud.go
+++ b/dns/tencent_cloud.go
@@ -18,9 +18,10 @@ const (
 // TencentCloud 腾讯云 DNSPod API 3.0 实现
 // https://cloud.tencent.com/document/api/1427/56193
 type TencentCloud struct {
-	DNS     config.DNS
-	Domains config.Domains
-	TTL     int
+	DNS        config.DNS
+	Domains    config.Domains
+	TTL        int
+	httpClient *http.Client
 }
 
 // TencentCloudRecord 腾讯云记录
@@ -79,6 +80,7 @@ func (tc *TencentCloud) Init(dnsConf *config.DnsConfig, ipv4cache *util.IpCache,
 			tc.TTL = ttl
 		}
 	}
+	tc.httpClient = dnsConf.GetHTTPClient()
 }
 
 // AddUpdateDomainRecords 添加或更新 IPv4/IPv6 记录
@@ -240,7 +242,7 @@ func (tc *TencentCloud) request(action string, data interface{}, result interfac
 
 	util.TencentCloudSigner(tc.DNS.ID, tc.DNS.Secret, req, action, string(jsonStr), util.DnsPod)
 
-	client := util.CreateHTTPClient()
+	client := tc.httpClient
 	resp, err := client.Do(req)
 	err = util.GetHTTPResponse(resp, err, result)
 

--- a/dns/traffic_route.go
+++ b/dns/traffic_route.go
@@ -2,6 +2,7 @@ package dns
 
 import (
 	"encoding/json"
+	"net/http"
 	"strconv"
 
 	"github.com/jeessy2/ddns-go/v6/config"
@@ -10,9 +11,10 @@ import (
 
 // TrafficRoute 火山引擎DNS服务
 type TrafficRoute struct {
-	DNS     config.DNS
-	Domains config.Domains
-	TTL     int
+	DNS        config.DNS
+	Domains    config.Domains
+	TTL        int
+	httpClient *http.Client
 }
 
 // TrafficRouteMeta 解析记录
@@ -83,6 +85,7 @@ func (tr *TrafficRoute) Init(dnsConf *config.DnsConfig, ipv4cache *util.IpCache,
 			tr.TTL = ttl
 		}
 	}
+	tr.httpClient = dnsConf.GetHTTPClient()
 }
 
 // AddUpdateDomainRecords 添加或更新IPv4/IPv6记录
@@ -282,7 +285,7 @@ func (tr *TrafficRoute) request(method string, action string, data interface{}, 
 		return err
 	}
 
-	client := util.CreateHTTPClient()
+	client := tr.httpClient
 	resp, err := client.Do(req)
 	return util.GetHTTPResponse(resp, err, result)
 }

--- a/dns/vercel.go
+++ b/dns/vercel.go
@@ -13,9 +13,10 @@ import (
 )
 
 type Vercel struct {
-	DNS     config.DNS
-	Domains config.Domains
-	TTL     int
+	DNS        config.DNS
+	Domains    config.Domains
+	TTL        int
+	httpClient *http.Client
 }
 
 type ListExistingRecordsResponse struct {
@@ -52,6 +53,7 @@ func (v *Vercel) Init(dnsConf *config.DnsConfig, ipv4cache *util.IpCache, ipv6ca
 		ttl = 60
 	}
 	v.TTL = ttl
+	v.httpClient = dnsConf.GetHTTPClient()
 }
 
 func (v *Vercel) AddUpdateDomainRecords() (domains config.Domains) {
@@ -170,7 +172,7 @@ func (v *Vercel) request(method, api string, data, result interface{}) (err erro
 	req.Header.Set("Authorization", "Bearer "+v.DNS.Secret)
 	req.Header.Set("Content-Type", "application/json")
 
-	client := util.CreateHTTPClient()
+	client := v.httpClient
 	resp, err := client.Do(req)
 	if err != nil {
 		return err

--- a/static/i18n.js
+++ b/static/i18n.js
@@ -214,6 +214,18 @@ const I18N_MAP = {
     'en': '<span style="color: red">No available network card found</span>',
     'zh-cn': '<span style="color: red">没有找到可用的网卡</span>'
   },
+  "Http Interface": {
+    'en': 'Http Interface',
+    'zh-cn': 'HTTP 请求网卡'
+  },
+  "Default": {
+    'en': 'Default',
+    'zh-cn': '默认'
+  },
+  "HttpInterfaceHelp": {
+    'en': 'Bind HTTP requests to a specific network interface (similar to curl --interface). Leave empty to use the default.',
+    'zh-cn': '发送 HTTP 请求时绑定指定网卡（类似 curl --interface）。留空则使用默认网卡。'
+  },
   "Login": {
     'en': 'Login',
     'zh-cn': '登录'

--- a/util/http_client_util.go
+++ b/util/http_client_util.go
@@ -3,6 +3,7 @@ package util
 import (
 	"context"
 	"crypto/tls"
+	"fmt"
 	"net"
 	"net/http"
 	"time"
@@ -26,11 +27,68 @@ var defaultTransport = &http.Transport{
 	ExpectContinueTimeout: 1 * time.Second,
 }
 
+// insecureSkipVerify 全局TLS验证跳过标志
+var insecureSkipVerify bool
+
 // CreateHTTPClient Create Default HTTP Client
 func CreateHTTPClient() *http.Client {
 	return &http.Client{
 		Timeout:   30 * time.Second,
 		Transport: defaultTransport,
+	}
+}
+
+// GetLocalAddrFromInterface 根据网卡名称获取本地IP地址
+func GetLocalAddrFromInterface(ifaceName string) (string, error) {
+	iface, err := net.InterfaceByName(ifaceName)
+	if err != nil {
+		return "", fmt.Errorf("找不到网卡 %s: %v", ifaceName, err)
+	}
+	addrs, err := iface.Addrs()
+	if err != nil {
+		return "", fmt.Errorf("获取网卡 %s 地址失败: %v", ifaceName, err)
+	}
+	for _, addr := range addrs {
+		if ipNet, ok := addr.(*net.IPNet); ok && ipNet.IP.IsGlobalUnicast() {
+			return ipNet.IP.String(), nil
+		}
+	}
+	return "", fmt.Errorf("网卡 %s 没有可用的单播地址", ifaceName)
+}
+
+// CreateHTTPClientWithInterface 创建绑定指定网卡的HTTP客户端
+func CreateHTTPClientWithInterface(ifaceName string) *http.Client {
+	if ifaceName == "" {
+		return CreateHTTPClient()
+	}
+	localIP, err := GetLocalAddrFromInterface(ifaceName)
+	if err != nil {
+		Log("绑定网卡失败, 将使用默认网卡. 网卡: %s, 错误: %s", ifaceName, err)
+		return CreateHTTPClient()
+	}
+	localAddr := &net.TCPAddr{IP: net.ParseIP(localIP)}
+	boundDialer := &net.Dialer{
+		Timeout:   30 * time.Second,
+		KeepAlive: 30 * time.Second,
+		LocalAddr: localAddr,
+	}
+	transport := &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: func(ctx context.Context, network, address string) (net.Conn, error) {
+			return boundDialer.DialContext(ctx, network, address)
+		},
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	}
+	if insecureSkipVerify {
+		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	}
+	return &http.Client{
+		Timeout:   30 * time.Second,
+		Transport: transport,
 	}
 }
 
@@ -83,6 +141,7 @@ func CreateNoProxyHTTPClient(network string) *http.Client {
 
 // SetInsecureSkipVerify 将所有 http.Transport 的 InsecureSkipVerify 设置为 true
 func SetInsecureSkipVerify() {
+	insecureSkipVerify = true
 	transports := []*http.Transport{defaultTransport, noProxyTcp4Transport, noProxyTcp6Transport}
 
 	for _, transport := range transports {

--- a/web/save.go
+++ b/web/save.go
@@ -101,6 +101,7 @@ func checkAndSave(request *http.Request) string {
 		dnsConf.Ipv6.Cmd = strings.TrimSpace(v.Ipv6Cmd)
 		dnsConf.Ipv6.Ipv6Reg = strings.TrimSpace(v.Ipv6Reg)
 		dnsConf.Ipv6.Domains = util.SplitLines(v.Ipv6Domains)
+		dnsConf.HttpInterface = strings.TrimSpace(v.HttpInterface)
 
 		if k < len(conf.DnsConf) {
 			c := &conf.DnsConf[k]

--- a/web/writing.html
+++ b/web/writing.html
@@ -120,6 +120,19 @@
                   <small data-i18n-html="ttlHelp" id="ttlHelp" class="form-text text-muted"></small>
                 </div>
               </div>
+
+              <div class="form-group row">
+                <label data-i18n="Http Interface" for="HttpInterface" class="col-sm-2 col-form-label">Http Interface</label>
+                <div class="col-sm-10">
+                  <select class="form-control form" name="HttpInterface" id="HttpInterface">
+                    <option data-i18n="Default" value="">Default</option>
+                    {{range .AllInterfaces}}
+                    <option value="{{.Name}}">{{.Name}}</option>
+                    {{end}}
+                  </select>
+                  <small data-i18n-html="HttpInterfaceHelp" id="HttpInterfaceHelp" class="form-text text-muted"></small>
+                </div>
+              </div>
             </div>
           </div>
 
@@ -376,6 +389,7 @@
     DnsName: "alidns",
     DnsSecret: "",
     DnsExtParam: "",
+    HttpInterface: "",
     Ipv4Cmd: "",
     Ipv4Domains: "",
     Ipv4Enable: true,


### PR DESCRIPTION
# What does this PR do?

Adds support for binding outbound HTTP requests to a specific network interface per DNS config entry — analogous to `curl --interface eth0`. When `HttpInterface` is set, DNS provider API calls use the bound NIC's local address as the TCP source.

## Core changes

- **`util/http_client_util.go`**: Added `GetLocalAddrFromInterface` (NIC name → IP) and `CreateHTTPClientWithInterface` (creates transport with `net.Dialer.LocalAddr` bound to that IP). Added package-level `insecureSkipVerify` flag so `-skipVerify` applies to interface-bound transports too.
- **`config/config.go`**: Added `HttpInterface string` to `DnsConfig` (serialized to YAML). Added `GetHTTPClient()` method that returns a bound or default client.
- **All 24 DNS providers** (`dns/*.go`): Each provider now stores `httpClient *http.Client` initialized in `Init()` via `dnsConf.GetHTTPClient()`, replacing per-request `util.CreateHTTPClient()` calls.
- **Web UI** (`web/`, `static/i18n.js`): Adds an "Http Interface" dropdown in the DNS Provider config panel, populated from all available network interfaces. Includes zh-cn / en i18n strings.

## Config example (YAML)

```yaml
DnsConf:
  - DNS:
      Name: cloudflare
      ID: ...
      Secret: ...
    HttpInterface: eth1   # bind all DNS API requests to eth1
```

# Motivation

Users with multiple NICs (e.g., multi-homed servers, policy routing setups) need control over which interface ddns-go uses for DNS provider API calls — the same need `curl --interface` serves.

# Additional Notes

If the specified interface is not found or has no global unicast address, ddns-go falls back to the default transport and logs a warning.