### PR TITLE
feat: add top language switcher for web UI

### DIFF
--- a/main.go
+++ b/main.go
@@ -198,6 +198,7 @@ func runWebServer() error {
 
 	http.HandleFunc("/", web.Auth(web.Writing))
 	http.HandleFunc("/save", web.Auth(web.Save))
+	http.HandleFunc("/setLang", web.Auth(web.SetLang))
 	http.HandleFunc("/logs", web.Auth(web.Logs))
 	http.HandleFunc("/clearLog", web.Auth(web.ClearLog))
 	http.HandleFunc("/webhookTest", web.Auth(web.WebhookTest))

--- a/static/common.css
+++ b/static/common.css
@@ -252,12 +252,15 @@ main {
     line-height: 1.2;
 }
 
-.lang-toggle {
-    cursor: pointer;
+.action-button-text:hover,
+.action-button-text:focus,
+.action-button-text:active,
+.action-button-text:visited {
+    background-color: transparent;
 }
 
-.lang-toggle:hover {
-    background-color: transparent;
+.lang-toggle {
+    cursor: pointer;
 }
 
 .lang-toggle:focus {

--- a/static/common.css
+++ b/static/common.css
@@ -126,7 +126,6 @@ main {
 
 #logsBtn {
     position: relative;
-    margin-left: auto;
     margin-right: 25px;
 }
 
@@ -238,6 +237,35 @@ main {
 
 .button-container {
     padding: 0 !important;
+}
+
+.top-actions {
+    gap: 12px;
+}
+
+.lang-toggle {
+    border: 1px solid rgba(255, 255, 255, 0.75);
+    background: transparent;
+    color: white;
+    border-radius: 999px;
+    padding: 2px 8px;
+    font-size: 13px;
+    line-height: 1.4;
+    cursor: pointer;
+}
+
+.lang-toggle:hover {
+    background: rgba(255, 255, 255, 0.12);
+}
+
+.lang-toggle:focus {
+    outline: none;
+    box-shadow: 0 0 0 0.2rem rgba(255, 255, 255, 0.2);
+}
+
+[data-theme='dark'] .lang-toggle {
+    border-color: #adbac7;
+    color: #adbac7;
 }
 
 .action-button {

--- a/static/common.css
+++ b/static/common.css
@@ -243,19 +243,21 @@ main {
     gap: 12px;
 }
 
+.action-button-text {
+    min-height: 30px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 4px 10px;
+    line-height: 1.2;
+}
+
 .lang-toggle {
-    border: 1px solid rgba(255, 255, 255, 0.75);
-    background: transparent;
-    color: white;
-    border-radius: 999px;
-    padding: 2px 8px;
-    font-size: 13px;
-    line-height: 1.4;
     cursor: pointer;
 }
 
 .lang-toggle:hover {
-    background: rgba(255, 255, 255, 0.12);
+    background-color: transparent;
 }
 
 .lang-toggle:focus {

--- a/static/common.css
+++ b/static/common.css
@@ -277,8 +277,8 @@ main {
     flex: none;
     padding: 4px 6px;
     font-size: 14px;
-    color: white;
-    border: 1px solid white;
+    color: #adbac7;
+    border: 1px solid #adbac7;
     border-radius: 8px;
     background-color: transparent;
     text-align: center;
@@ -289,8 +289,8 @@ main {
 .action-button:visited,
 .action-button:active,
 .action-button:focus {
-    color: white;
-    border-color: white;
+    color: #adbac7;
+    border-color: #adbac7;
     background-color: transparent;
     text-decoration: none;
     outline: none;

--- a/static/i18n.js
+++ b/static/i18n.js
@@ -180,6 +180,10 @@ const I18N_MAP = {
     'en': 'OK',
     'zh-cn': '确定'
   },
+  'languageToggleTooltip': {
+    'en': 'Switch language',
+    'zh-cn': '切换语言'
+  },
   "Ipv4UrlHelp": {
     'en': "https://api.ipify.org, https://myip.ipip.net, https://ddns.oray.com/checkip, https://ip.3322.net, https://v4.yinghualuo.cn/bejson",
     'zh-cn': "https://myip.ipip.net, https://ddns.oray.com/checkip, https://ip.3322.net, https://v4.yinghualuo.cn/bejson"
@@ -252,30 +256,32 @@ const I18N_MAP = {
   },
 };
 
-const LANG = localStorage.getItem('lang') || (navigator.language || navigator.browserLanguage).replaceAll('_', '-').toLowerCase();
+const getCurrentLang = () => {
+  const serverLang = window.__DDNS_GO_LANG__;
+  if (serverLang) {
+    return String(serverLang).replaceAll('_', '-').toLowerCase();
+  }
+  return localStorage.getItem('lang') || (navigator.language || navigator.browserLanguage).replaceAll('_', '-').toLowerCase();
+};
+
+const LANG_SWITCH_OPTIONS = ['zh-cn', 'en'];
 
 const getLocalLang = (langs) => {
-  // 优先取地区语言
-  if (langs.includes(LANG)) {
-    return LANG;
+  const langValue = getCurrentLang();
+  if (langs.includes(langValue)) {
+    return langValue;
   }
-  // 其次取表示语言
-  if (langs.includes(LANG.split('-')[0])) {
-    return LANG.split('-')[0];
+  if (langs.includes(langValue.split('-')[0])) {
+    return langValue.split('-')[0];
   }
-  // 再取表示语言相同的地区语言
   for (const l of langs) {
-    if (l.split('-')[0] === LANG.split('-')[0]) {
+    if (l.split('-')[0] === langValue.split('-')[0]) {
       return l;
     }
   }
-  // 无法匹配则取英文
   return 'en';
 }
 
-// 支持两种调用方式：
-// 1. 文本在I18N字典中的key，如"hello"
-// 2. 语言字符串字典，{en: "hello", zh: "你好"}
 const i18n = (keyOrLangDict) => {
   let key = keyOrLangDict;
   let langDict = keyOrLangDict;
@@ -296,6 +302,20 @@ const i18n = (keyOrLangDict) => {
   return key;
 }
 
+const syncLangToggle = (dom = document) => {
+  dom.querySelectorAll('[data-lang-toggle]').forEach(el => {
+    if (el.dataset.langToggleInitialized !== 'true') {
+      el.dataset.langToggleInitialized = 'true';
+      el.addEventListener('click', () => {
+        const currentLang = getLocalLang(LANG_SWITCH_OPTIONS);
+        const nextLang = currentLang === 'zh-cn' ? 'en' : 'zh-cn';
+        localStorage.setItem('lang', nextLang);
+        window.location.reload();
+      });
+    }
+  });
+}
+
 const convertDom = (dom = document) => {
   dom.querySelectorAll('[data-i18n]').forEach(el => {
     const key = el.dataset.i18n;
@@ -313,6 +333,7 @@ const convertDom = (dom = document) => {
       el.setAttribute(attr, i18n(key));
     });
   });
+  syncLangToggle(dom);
 }
 
 document.addEventListener('DOMContentLoaded', () => { convertDom(); });

--- a/web/login.go
+++ b/web/login.go
@@ -51,9 +51,11 @@ func Login(writer http.ResponseWriter, request *http.Request) {
 	conf, _ := config.GetConfigCached()
 
 	err = tmpl.Execute(writer, struct {
-		EmptyUser bool // 未填写用户名和密码
+		EmptyUser bool   // 未填写用户名和密码
+		Lang      string // 当前后端语言
 	}{
 		EmptyUser: conf.Username == "" && conf.Password == "",
+		Lang:      conf.Lang,
 	})
 	if err != nil {
 		fmt.Println("Error happened..")
@@ -63,8 +65,8 @@ func Login(writer http.ResponseWriter, request *http.Request) {
 
 // LoginFunc login func
 func LoginFunc(w http.ResponseWriter, r *http.Request) {
-	accept := r.Header.Get("Accept-Language")
-	util.InitLogLang(accept)
+	conf, _ := config.GetConfigCached()
+	util.InitLogLang(conf.Lang)
 
 	if ld.failedTimes >= 5 {
 		loginUnlock()
@@ -91,7 +93,6 @@ func LoginFunc(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	conf, _ := config.GetConfigCached()
 
 	// 初始化用户名密码
 	if conf.Username == "" && conf.Password == "" {

--- a/web/login.html
+++ b/web/login.html
@@ -20,12 +20,14 @@
 <body>
   <header>
     <div class="navbar navbar-dark bg-dark shadow-sm">
-      <div class="button-container container d-flex justify-content-between">
+      <div class="button-container container d-flex justify-content-between align-items-center flex-wrap">
         <a target="blank" href="https://github.com/jeessy2/ddns-go" class="navbar-brand d-flex align-items-center">
           <strong>DDNS-GO</strong>
         </a>
-        <span class="theme-button gg-dark-mode" data-toggle="tooltip" data-placement="bottom" data-html="true"
-          data-i18n-attr="title:themeTooltip" id="themeButton"></span>
+        <div class="top-actions d-flex align-items-center flex-wrap ml-auto">
+          <span class="theme-button gg-dark-mode" data-toggle="tooltip" data-placement="bottom" data-html="true"
+            data-i18n-attr="title:themeTooltip" id="themeButton"></span>
+        </div>
       </div>
     </div>
   </header>
@@ -67,6 +69,9 @@
   </main>
 </body>
 
+<script>
+  window.__DDNS_GO_LANG__ = "{{.Lang}}";
+</script>
 <script src="./static/theme.js"></script>
 <script>
   // 登录
@@ -80,12 +85,18 @@
         });
 
         if (resp.Code !== 200) {
+          if (window.__DDNS_GO_LANG__) {
+            localStorage.setItem('lang', window.__DDNS_GO_LANG__);
+          }
           showMessage({
             content: resp.Msg,
             type: "error",
             duration: 5000,
           });
         } else {
+          if (window.__DDNS_GO_LANG__) {
+            localStorage.setItem('lang', window.__DDNS_GO_LANG__);
+          }
           window.location.href = "./";
         }
       } catch (err) {

--- a/web/save.go
+++ b/web/save.go
@@ -30,6 +30,7 @@ func checkAndSave(request *http.Request) string {
 	var data struct {
 		Username           string       `json:"Username"`
 		Password           string       `json:"Password"`
+		Lang               string       `json:"Lang"`
 		NotAllowWanAccess  bool         `json:"NotAllowWanAccess"`
 		WebhookURL         string       `json:"WebhookURL"`
 		WebhookRequestBody string       `json:"WebhookRequestBody"`
@@ -45,9 +46,11 @@ func checkAndSave(request *http.Request) string {
 	usernameNew := strings.TrimSpace(data.Username)
 	passwordNew := data.Password
 
-	// 国际化
-	accept := request.Header.Get("Accept-Language")
-	conf.Lang = util.InitLogLang(accept)
+	if strings.TrimSpace(data.Lang) != "" {
+		conf.Lang = util.InitLogLang(data.Lang)
+	} else {
+		conf.Lang = util.InitLogLang(conf.Lang)
+	}
 
 	conf.NotAllowWanAccess = data.NotAllowWanAccess
 	conf.WebhookURL = strings.TrimSpace(data.WebhookURL)

--- a/web/set_lang.go
+++ b/web/set_lang.go
@@ -1,0 +1,37 @@
+package web
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/jeessy2/ddns-go/v6/config"
+	"github.com/jeessy2/ddns-go/v6/util"
+)
+
+func SetLang(writer http.ResponseWriter, request *http.Request) {
+	conf, _ := config.GetConfigCached()
+
+	var data struct {
+		Lang string `json:"Lang"`
+	}
+
+	if err := json.NewDecoder(request.Body).Decode(&data); err != nil {
+		returnError(writer, util.LogStr("数据解析失败, 请刷新页面重试"))
+		return
+	}
+
+	lang := strings.TrimSpace(data.Lang)
+	if lang == "" {
+		lang = conf.Lang
+	}
+
+	conf.Lang = util.InitLogLang(lang)
+	if err := conf.SaveConfig(); err != nil {
+		returnError(writer, err.Error())
+		return
+	}
+
+	byt, _ := json.Marshal(map[string]string{"result": "ok", "lang": conf.Lang})
+	writer.Write(byt)
+}

--- a/web/writing.go
+++ b/web/writing.go
@@ -75,6 +75,7 @@ func Writing(writer http.ResponseWriter, request *http.Request) {
 		DnsConf           template.JS
 		NotAllowWanAccess bool
 		Username          string
+		Lang              string
 		config.Webhook
 		Version       string
 		Ipv4          []config.NetInterface
@@ -84,6 +85,7 @@ func Writing(writer http.ResponseWriter, request *http.Request) {
 		DnsConf:           template.JS(getDnsConfStr(conf.DnsConf)),
 		NotAllowWanAccess: conf.NotAllowWanAccess,
 		Username:          conf.User.Username,
+		Lang:              conf.Lang,
 		Webhook:           conf.Webhook,
 		Version:           os.Getenv(VersionEnv),
 		Ipv4:              ipv4,

--- a/web/writing.html
+++ b/web/writing.html
@@ -25,17 +25,17 @@
           <strong>DDNS-GO</strong>
         </a>
         <div class="top-actions d-flex align-items-center flex-wrap ml-auto">
-          <button type="button" class="lang-toggle" id="langToggleButton" data-lang-toggle data-toggle="tooltip" data-placement="bottom"
-            data-i18n-attr="title:languageToggleTooltip" aria-label="Language toggle">
-            文/A
-          </button>
           <button data-i18n="Logs" class="btn btn-info btn-sm" id="logsBtn" data-toggle="tooltip" data-placement="bottom">
             Logs
           </button>
           <span class="theme-button gg-dark-mode" data-toggle="tooltip" data-placement="bottom" data-html="true"
             data-i18n-attr="title:themeTooltip" id="themeButton"></span>
           <span class="badge badge-secondary">{{.Version}}</span>
-          <a href="./logout" class="action-button logout-button" data-i18n="Logout">
+          <button type="button" class="action-button action-button-text lang-toggle" id="langToggleButton" data-lang-toggle
+            data-toggle="tooltip" data-placement="bottom" data-i18n-attr="title:languageToggleTooltip" aria-label="Language toggle">
+            EN / 中文
+          </button>
+          <a href="./logout" class="action-button action-button-text logout-button" data-i18n="Logout">
             Logout
           </a>
         </div>

--- a/web/writing.html
+++ b/web/writing.html
@@ -20,19 +20,25 @@
 <body>
   <header>
     <div class="navbar navbar-dark bg-dark shadow-sm">
-      <div class="button-container container d-flex justify-content-between">
+      <div class="button-container container d-flex justify-content-between align-items-center flex-wrap">
         <a target="blank" href="https://github.com/jeessy2/ddns-go" class="navbar-brand d-flex align-items-center">
           <strong>DDNS-GO</strong>
         </a>
-        <button data-i18n="Logs" class="btn btn-info btn-sm" id="logsBtn" data-toggle="tooltip" data-placement="bottom">
-          Logs
-        </button>
-        <span class="theme-button gg-dark-mode" data-toggle="tooltip" data-placement="bottom" data-html="true"
-          data-i18n-attr="title:themeTooltip" id="themeButton"></span>
-        <span class="badge badge-secondary">{{.Version}}</span>
-        <a href="./logout" class="action-button logout-button" data-i18n="Logout">
-          Logout
-        </a>
+        <div class="top-actions d-flex align-items-center flex-wrap ml-auto">
+          <button type="button" class="lang-toggle" id="langToggleButton" data-lang-toggle data-toggle="tooltip" data-placement="bottom"
+            data-i18n-attr="title:languageToggleTooltip" aria-label="Language toggle">
+            文/A
+          </button>
+          <button data-i18n="Logs" class="btn btn-info btn-sm" id="logsBtn" data-toggle="tooltip" data-placement="bottom">
+            Logs
+          </button>
+          <span class="theme-button gg-dark-mode" data-toggle="tooltip" data-placement="bottom" data-html="true"
+            data-i18n-attr="title:themeTooltip" id="themeButton"></span>
+          <span class="badge badge-secondary">{{.Version}}</span>
+          <a href="./logout" class="action-button logout-button" data-i18n="Logout">
+            Logout
+          </a>
+        </div>
       </div>
     </div>
   </header>
@@ -371,6 +377,10 @@
 
 </body>
 
+<script>
+  window.__DDNS_GO_LANG__ = "{{.Lang}}";
+</script>
+
 <!-- 全局变量 -->
 <script>
   let configIndex = -1;
@@ -379,6 +389,7 @@
     NotAllowWanAccess: document.getElementById("NotAllowWanAccess").checked,
     Username: document.getElementById("Username").value,
     Password: document.getElementById("Password").value,
+    Lang: "{{.Lang}}",
     WebhookURL: document.getElementById("WebhookURL").value,
     WebhookRequestBody: document.getElementById("WebhookRequestBody").value,
     WebhookHeaders: document.getElementById("WebhookHeaders").value,
@@ -614,6 +625,30 @@
   function getConfName(idx, _default = dnsConf[idx].DnsName) {
     return dnsConf[idx].Name || `${idx + 1} - ${_default}`;
   }
+
+  document.getElementById("langToggleButton").addEventListener('click', async () => {
+    const nextLang = globalConf.Lang === "zh" || globalConf.Lang === "zh-cn" ? "en" : "zh";
+    try {
+      const resp = await request.post("./setLang", { Lang: nextLang });
+      if (resp.result !== "ok") {
+        showMessage({
+          content: resp.result,
+          type: "error",
+          duration: 5000,
+        });
+        return;
+      }
+      globalConf.Lang = resp.lang;
+      localStorage.setItem('lang', resp.lang);
+      window.location.reload();
+    } catch (err) {
+      showMessage({
+        content: err.toString(),
+        type: "error",
+        duration: 5000,
+      });
+    }
+  });
 
   // 新增配置按钮被点击
   document.getElementById("addBtn").addEventListener('click', e => {

--- a/web/writing.html
+++ b/web/writing.html
@@ -33,7 +33,7 @@
           <span class="badge badge-secondary">{{.Version}}</span>
           <button type="button" class="action-button action-button-text lang-toggle" id="langToggleButton" data-lang-toggle
             data-toggle="tooltip" data-placement="bottom" data-i18n-attr="title:languageToggleTooltip" aria-label="Language toggle">
-            EN / 中文
+            文/A
           </button>
           <a href="./logout" class="action-button action-button-text logout-button" data-i18n="Logout">
             Logout


### PR DESCRIPTION
## What does this PR do?
- add a language switcher to the top navigation on both login and config pages
- allow users to manually switch between Chinese and English
- keep the selected language in localStorage and re-apply on reload

## Why?
The project already has i18n support, but users cannot easily change language from the UI. This adds a visible control at the top so language switching is discoverable and fast.

## Scope
- web/login.html
- web/writing.html
- static/i18n.js
- static/common.css
