### PR TITLE
fix: move myip.ipip.net to end of default URLs

### DIFF
--- a/static/i18n.js
+++ b/static/i18n.js
@@ -185,8 +185,8 @@ const I18N_MAP = {
     'zh-cn': '切换语言'
   },
   "Ipv4UrlHelp": {
-    'en': "https://api.ipify.org, https://myip.ipip.net, https://ddns.oray.com/checkip, https://ip.3322.net, https://v4.yinghualuo.cn/bejson",
-    'zh-cn': "https://myip.ipip.net, https://ddns.oray.com/checkip, https://ip.3322.net, https://v4.yinghualuo.cn/bejson"
+    'en': "https://api.ipify.org, https://ddns.oray.com/checkip, https://ip.3322.net, https://v4.yinghualuo.cn/bejson, https://myip.ipip.net",
+    'zh-cn': "https://ddns.oray.com/checkip, https://ip.3322.net, https://v4.yinghualuo.cn/bejson, https://myip.ipip.net"
   },
   "Ipv6UrlHelp": {
     'en': "https://speed.neu6.edu.cn/getIP.php, https://v6.ident.me, https://6.ipw.cn, https://v6.yinghualuo.cn/bejson",

--- a/web/writing.html
+++ b/web/writing.html
@@ -408,7 +408,7 @@
     Ipv4NetInterface: "",
     Ipv4Url: i18n({
       "en": "https://api.ipify.org, https://ddns.oray.com/checkip, https://ip.3322.net, https://4.ipw.cn, https://v4.yinghualuo.cn/bejson",
-      "zh-cn": "https://myip.ipip.net, https://ddns.oray.com/checkip, https://ip.3322.net, https://4.ipw.cn, https://v4.yinghualuo.cn/bejson",
+      "zh-cn": "https://ddns.oray.com/checkip, https://ip.3322.net, https://4.ipw.cn, https://v4.yinghualuo.cn/bejson, https://myip.ipip.net",
     }),
     Ipv6Cmd: "",
     Ipv6Domains: "",


### PR DESCRIPTION
Move myip.ipip.net to the end of the frontend IPv4 default URL lists.

Validation:
- git diff --check