### PR TITLE
fix(edgeone): 修复 #1683 普通 DNS 更新被源站组逻辑跳过

### DIFF
--- a/dns/edgeone.go
+++ b/dns/edgeone.go
@@ -97,15 +97,16 @@ func (eo *EdgeOne) Init(dnsConf *config.DnsConfig, ipv4cache *util.IpCache, ipv6
 
 // AddUpdateDomainRecords 添加或更新 IPv4/IPv6 记录
 func (eo *EdgeOne) AddUpdateDomainRecords() config.Domains {
-	eo.addUpdateOriginGroups(eo.Domains.GetAllNewIpResult("A/AAAA"))
-	eo.addUpdateDomainRecords("A")
-	eo.addUpdateDomainRecords("AAAA")
+	ipv4Addr, ipv4Domains := eo.Domains.GetNewIpResult("A")
+	ipv6Addr, ipv6Domains := eo.Domains.GetNewIpResult("AAAA")
+
+	eo.addUpdateOriginGroups(buildEdgeOneDomainTuples(eo.Domains, ipv4Addr, ipv4Domains, ipv6Addr, ipv6Domains))
+	eo.addUpdateDomainRecords("A", ipv4Addr, ipv4Domains)
+	eo.addUpdateDomainRecords("AAAA", ipv6Addr, ipv6Domains)
 	return eo.Domains
 }
 
-func (eo *EdgeOne) addUpdateDomainRecords(recordType string) {
-	ipAddr, domains := eo.Domains.GetNewIpResult(recordType)
-
+func (eo *EdgeOne) addUpdateDomainRecords(recordType string, ipAddr string, domains []*config.Domain) {
 	if ipAddr == "" {
 		return
 	}

--- a/dns/edgeone_origin.go
+++ b/dns/edgeone_origin.go
@@ -66,6 +66,60 @@ func (eo *EdgeOne) addUpdateOriginGroups(domainCache config.DomainTuples) {
 	}
 }
 
+func buildEdgeOneDomainTuples(domains config.Domains, ipv4Addr string, ipv4Domains []*config.Domain, ipv6Addr string, ipv6Domains []*config.Domain) config.DomainTuples {
+	cap := 0
+	if ipv4Addr != "" {
+		cap += len(ipv4Domains)
+	}
+	if ipv6Addr != "" {
+		cap += len(ipv6Domains)
+	}
+	if cap == 0 {
+		return nil
+	}
+
+	results := make(config.DomainTuples, cap)
+	appendEdgeOneDomainTuples(results, ipv4Addr, ipv4Domains, config.DomainTuple{
+		RecordType: "A",
+		Ipv4Addr:   domains.Ipv4Addr,
+		Ipv6Addr:   domains.Ipv6Addr,
+	})
+	appendEdgeOneDomainTuples(results, ipv6Addr, ipv6Domains, config.DomainTuple{
+		RecordType: "AAAA",
+		Ipv4Addr:   domains.Ipv4Addr,
+		Ipv6Addr:   domains.Ipv6Addr,
+	})
+	return results
+}
+
+func appendEdgeOneDomainTuples(results config.DomainTuples, ipAddr string, domains []*config.Domain, template config.DomainTuple) {
+	if ipAddr == "" {
+		return
+	}
+
+	for _, domain := range domains {
+		if domain == nil {
+			continue
+		}
+		domainStr := domain.String()
+		if tuple, ok := results[domainStr]; ok {
+			if tuple.RecordType != template.RecordType {
+				tuple.RecordType = "A/AAAA"
+			}
+			tuple.Primary = domain
+			tuple.Domains = append(tuple.Domains, domain)
+			tuple.IpAddrs = append(tuple.IpAddrs, ipAddr)
+			continue
+		}
+
+		tuple := template
+		tuple.Primary = domain
+		tuple.Domains = []*config.Domain{domain}
+		tuple.IpAddrs = []string{ipAddr}
+		results[domainStr] = &tuple
+	}
+}
+
 func (eo *EdgeOne) isOriginGroupDomain(domain *config.Domain) bool {
 	if domain == nil {
 		return false

--- a/dns/edgeone_origin_test.go
+++ b/dns/edgeone_origin_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/jeessy2/ddns-go/v6/config"
+	"github.com/jeessy2/ddns-go/v6/util"
 )
 
 func TestEdgeOneIsOriginGroupDomain(t *testing.T) {
@@ -42,5 +43,46 @@ func TestSameEdgeOneOriginRecords(t *testing.T) {
 	desired[1].Weight = 90
 	if sameEdgeOneOriginRecords(current, desired) {
 		t.Fatal("expected weight difference to be treated as a change")
+	}
+}
+
+func TestBuildEdgeOneDomainTuplesKeepsCombinedAddresses(t *testing.T) {
+	domain := &config.Domain{
+		DomainName:   "example.com",
+		CustomParams: "GroupId=origin-123",
+	}
+	results := buildEdgeOneDomainTuples(
+		config.Domains{
+			Ipv4Addr: "1.1.1.1",
+			Ipv6Addr: "2001:db8::1",
+		},
+		"1.1.1.1",
+		[]*config.Domain{domain},
+		"",
+		nil,
+	)
+	if len(results) != 1 {
+		t.Fatalf("expected 1 tuple, got %d", len(results))
+	}
+
+	tuple := results[domain.String()]
+	if tuple == nil {
+		t.Fatal("expected tuple to exist")
+	}
+	if tuple.RecordType != "A" {
+		t.Fatalf("expected record type A, got %s", tuple.RecordType)
+	}
+	if tuple.Ipv4Addr != "1.1.1.1" || tuple.Ipv6Addr != "2001:db8::1" {
+		t.Fatalf("expected both current addresses to be preserved, got ipv4=%s ipv6=%s", tuple.Ipv4Addr, tuple.Ipv6Addr)
+	}
+}
+
+func TestIpCacheSingleRoundReuse(t *testing.T) {
+	cache := util.IpCache{}
+	if !cache.Check("1.1.1.1") {
+		t.Fatal("expected first check to trigger compare")
+	}
+	if cache.Check("1.1.1.1") {
+		t.Fatal("expected second check in same state to be skipped")
 	}
 }


### PR DESCRIPTION
# What does this PR do?
修复 EdgeOne 在同时支持源站组更新后，普通 DNS 记录更新可能被跳过的问题。
# Motivation

# Additional Notes
