### PR TITLE
fix: block public first-time setup

### DIFF
--- a/web/login.go
+++ b/web/login.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"html/template"
 	"net/http"
-	"net/url"
 	"time"
 
 	"github.com/jeessy2/ddns-go/v6/config"
@@ -93,7 +92,6 @@ func LoginFunc(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-
 	// 初始化用户名密码
 	if conf.Username == "" && conf.Password == "" {
 		if time.Since(startTime) > saveLimit {
@@ -101,11 +99,12 @@ func LoginFunc(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		conf.NotAllowWanAccess = true
-		u, err := url.Parse(r.Header.Get("referer"))
-		if err == nil && !util.IsPrivateNetwork(u.Host) {
-			conf.NotAllowWanAccess = false
+		if !util.IsPrivateNetwork(r.RemoteAddr) {
+			returnForbidden(w, util.LogStr("首次配置仅允许从内网访问"))
+			return
 		}
+
+		conf.NotAllowWanAccess = true
 
 		conf.Username = data.Username
 		hashedPwd, err := conf.CheckPassword(data.Password)

--- a/web/login.go
+++ b/web/login.go
@@ -99,7 +99,14 @@ func LoginFunc(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		if !util.IsPrivateNetwork(r.RemoteAddr) {
+		clientAddr := r.RemoteAddr
+		// If requests come through a (trusted) local/LAN reverse proxy, use its reported client IP.
+		if util.IsPrivateNetwork(r.RemoteAddr) {
+			if realIP := r.Header.Get("X-Real-IP"); realIP != "" {
+				clientAddr = realIP
+			}
+		}
+		if !util.IsPrivateNetwork(clientAddr) {
 			returnForbidden(w, util.LogStr("首次配置仅允许从内网访问"))
 			return
 		}

--- a/web/return_json.go
+++ b/web/return_json.go
@@ -22,6 +22,16 @@ func returnError(w http.ResponseWriter, msg string) {
 	json.NewEncoder(w).Encode(result)
 }
 
+func returnForbidden(w http.ResponseWriter, msg string) {
+	result := &Result{}
+
+	result.Code = http.StatusForbidden
+	result.Msg = msg
+
+	w.WriteHeader(http.StatusForbidden)
+	json.NewEncoder(w).Encode(result)
+}
+
 // returnOK	返回成功信息
 func returnOK(w http.ResponseWriter, msg string, data interface{}) {
 	result := &Result{}


### PR DESCRIPTION

# What does this PR do?

This PR fixes a first-time setup security issue where a public client could initialize the admin account via `/loginFunc` by relying on spoofable `Referer` behavior.

修复首次配置阶段的 WAN 绕过问题：公网客户端不应通过伪造或操控 `Referer` 来完成管理员账号初始化。

## Changes:

- Use TCP-level `r.RemoteAddr` to decide whether first-time setup is allowed.
- Return `403 Forbidden` for public first-time setup requests.
- Remove `Referer`-based `NotAllowWanAccess` decision logic.
- Keep `NotAllowWanAccess = true` after successful private first-time setup.

# Motivation

The previous first-time setup flow trusted `Referer` when deciding WAN access behavior. `Referer` is fully client-controlled, so a public client could influence setup behavior during the initial configuration window.

之前首次配置逻辑依赖 `Referer` 判断来源，而 `Referer` 可由客户端伪造。首次安装窗口内，这会导致公网请求存在初始化管理员账号的风险。

# Additional Notes
none.