### PR TITLE
fix: enforce WAN checks behind trusted proxies | 修复反代场景 WAN 封锁

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,16 @@
 
 > [!NOTE]
 > 建议在启用公网访问时，使用 Nginx 等反向代理软件启用 HTTPS 访问，以保证安全性。[FAQ](https://github.com/jeessy2/ddns-go/wiki/FAQ)
+>
+> 如果启用“禁止公网访问”且 ddns-go 位于可信反向代理之后，可在配置文件中添加可信代理地址，使 ddns-go 使用代理传递的真实客户端 IP：
+> ```yaml
+> TrustedProxies:
+>   - 127.0.0.1
+>   - ::1
+>   - 192.168.1.10
+>   - 172.18.0.0/16
+> ```
+> 仅当请求来自这些可信代理时，才会读取 `X-Real-IP` / `X-Forwarded-For`。
 
 ## 系统中使用
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -32,6 +32,16 @@ Automatically obtain your public IPv4 or IPv6 address and resolve it to the corr
 
 > [!NOTE]
 > If you enable public network access, it is recommended to use Nginx and other reverse proxy software to enable HTTPS access to ensure security.
+>
+> If "Deny from WAN" is enabled and ddns-go runs behind a trusted reverse proxy, add trusted proxy addresses to the config file so ddns-go can use the original client IP reported by the proxy:
+> ```yaml
+> TrustedProxies:
+>   - 127.0.0.1
+>   - ::1
+>   - 192.168.1.10
+>   - 172.18.0.0/16
+> ```
+> `X-Real-IP` / `X-Forwarded-For` are used only when the request comes from these trusted proxies.
 
 ## Use in system
 

--- a/config/config.go
+++ b/config/config.go
@@ -72,6 +72,8 @@ type Config struct {
 	Webhook
 	// 禁止公网访问
 	NotAllowWanAccess bool
+	// 可信反向代理地址，支持 IP 或 CIDR
+	TrustedProxies []string
 	// 语言
 	Lang string
 }

--- a/util/net.go
+++ b/util/net.go
@@ -31,6 +31,58 @@ func IsPrivateNetwork(remoteAddr string) bool {
 	return false
 }
 
+func ClientIPFromRequest(r *http.Request, trustedProxies []string) (string, bool) {
+	peerIP := parseIPFromAddr(r.RemoteAddr)
+	if peerIP == nil {
+		return "", false
+	}
+
+	if !isTrustedProxy(peerIP, trustedProxies) {
+		return peerIP.String(), true
+	}
+
+	if realIP := parseIPFromAddr(r.Header.Get("X-Real-IP")); realIP != nil {
+		return realIP.String(), true
+	}
+
+	for _, forwardedIP := range strings.Split(r.Header.Get("X-Forwarded-For"), ",") {
+		if ip := parseIPFromAddr(forwardedIP); ip != nil {
+			return ip.String(), true
+		}
+	}
+
+	return "", false
+}
+
+func isTrustedProxy(peerIP net.IP, trustedProxies []string) bool {
+	for _, trustedProxy := range trustedProxies {
+		trustedProxy = strings.TrimSpace(trustedProxy)
+		if trustedProxy == "" {
+			continue
+		}
+		if trustedIP := parseIPFromAddr(trustedProxy); trustedIP != nil && trustedIP.Equal(peerIP) {
+			return true
+		}
+		if _, trustedNet, err := net.ParseCIDR(trustedProxy); err == nil && trustedNet.Contains(peerIP) {
+			return true
+		}
+	}
+	return false
+}
+
+func parseIPFromAddr(addr string) net.IP {
+	addr = strings.TrimSpace(addr)
+	if addr == "" {
+		return nil
+	}
+
+	if host, _, err := net.SplitHostPort(addr); err == nil {
+		addr = host
+	}
+	addr = strings.TrimPrefix(strings.TrimSuffix(addr, "]"), "[")
+	return net.ParseIP(addr)
+}
+
 // GetRequestIPStr get IP string from request
 func GetRequestIPStr(r *http.Request) (addr string) {
 	addr = "Remote: " + r.RemoteAddr

--- a/web/auth.go
+++ b/web/auth.go
@@ -11,6 +11,11 @@ import (
 // ViewFunc func
 type ViewFunc func(http.ResponseWriter, *http.Request)
 
+func isPrivateClientRequest(r *http.Request, trustedProxies []string) bool {
+	clientIP, ok := util.ClientIPFromRequest(r, trustedProxies)
+	return ok && util.IsPrivateNetwork(clientIP)
+}
+
 // Auth 验证Token是否已经通过
 func Auth(f ViewFunc) ViewFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
@@ -24,7 +29,7 @@ func Auth(f ViewFunc) ViewFunc {
 
 		// 禁止公网访问
 		if conf.NotAllowWanAccess {
-			if !util.IsPrivateNetwork(r.RemoteAddr) {
+			if !isPrivateClientRequest(r, conf.TrustedProxies) {
 				w.WriteHeader(http.StatusForbidden)
 				util.Log("%q 被禁止从公网访问", util.GetRequestIPStr(r))
 				return
@@ -51,7 +56,7 @@ func AuthAssert(f ViewFunc) ViewFunc {
 
 		// 配置文件为空, 启动时间超过3小时禁止从公网访问
 		if err != nil &&
-			time.Since(startTime) > time.Duration(3*time.Hour) && !util.IsPrivateNetwork(r.RemoteAddr) {
+			time.Since(startTime) > time.Duration(3*time.Hour) && !isPrivateClientRequest(r, conf.TrustedProxies) {
 			w.WriteHeader(http.StatusForbidden)
 			util.Log("%q 配置文件为空, 超过3小时禁止从公网访问", util.GetRequestIPStr(r))
 			return
@@ -59,7 +64,7 @@ func AuthAssert(f ViewFunc) ViewFunc {
 
 		// 禁止公网访问
 		if conf.NotAllowWanAccess {
-			if !util.IsPrivateNetwork(r.RemoteAddr) {
+			if !isPrivateClientRequest(r, conf.TrustedProxies) {
 				w.WriteHeader(http.StatusForbidden)
 				util.Log("%q 被禁止从公网访问", util.GetRequestIPStr(r))
 				return

--- a/web/login.go
+++ b/web/login.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"html/template"
 	"net/http"
-	"net/url"
 	"time"
 
 	"github.com/jeessy2/ddns-go/v6/config"
@@ -93,7 +92,6 @@ func LoginFunc(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-
 	// 初始化用户名密码
 	if conf.Username == "" && conf.Password == "" {
 		if time.Since(startTime) > saveLimit {
@@ -101,11 +99,19 @@ func LoginFunc(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		conf.NotAllowWanAccess = true
-		u, err := url.Parse(r.Header.Get("referer"))
-		if err == nil && !util.IsPrivateNetwork(u.Host) {
-			conf.NotAllowWanAccess = false
+		clientAddr := r.RemoteAddr
+		// If requests come through a (trusted) local/LAN reverse proxy, use its reported client IP.
+		if util.IsPrivateNetwork(r.RemoteAddr) {
+			if realIP := r.Header.Get("X-Real-IP"); realIP != "" {
+				clientAddr = realIP
+			}
 		}
+		if !util.IsPrivateNetwork(clientAddr) {
+			returnForbidden(w, util.LogStr("首次配置仅允许从内网访问"))
+			return
+		}
+
+		conf.NotAllowWanAccess = true
 
 		conf.Username = data.Username
 		hashedPwd, err := conf.CheckPassword(data.Password)

--- a/web/login.go
+++ b/web/login.go
@@ -99,14 +99,7 @@ func LoginFunc(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		clientAddr := r.RemoteAddr
-		// If requests come through a (trusted) local/LAN reverse proxy, use its reported client IP.
-		if util.IsPrivateNetwork(r.RemoteAddr) {
-			if realIP := r.Header.Get("X-Real-IP"); realIP != "" {
-				clientAddr = realIP
-			}
-		}
-		if !util.IsPrivateNetwork(clientAddr) {
+		if !isPrivateClientRequest(r, conf.TrustedProxies) {
 			returnForbidden(w, util.LogStr("首次配置仅允许从内网访问"))
 			return
 		}

--- a/web/return_json.go
+++ b/web/return_json.go
@@ -22,6 +22,16 @@ func returnError(w http.ResponseWriter, msg string) {
 	json.NewEncoder(w).Encode(result)
 }
 
+func returnForbidden(w http.ResponseWriter, msg string) {
+	result := &Result{}
+
+	result.Code = http.StatusForbidden
+	result.Msg = msg
+
+	w.WriteHeader(http.StatusForbidden)
+	json.NewEncoder(w).Encode(result)
+}
+
 // returnOK	返回成功信息
 func returnOK(w http.ResponseWriter, msg string, data interface{}) {
 	result := &Result{}


### PR DESCRIPTION

# What does this PR do?

This PR fixes WAN access checks when ddns-go is deployed behind a reverse proxy.

修复 ddns-go 位于反向代理后时，“禁止公网访问 / Deny from WAN” 判断失效的问题。

## Main changes

- Add `TrustedProxies []string` YAML config for trusted reverse proxy IPs/CIDRs.
- Resolve the real client IP via `X-Real-IP` / `X-Forwarded-For` only when the TCP peer is in `TrustedProxies`.
- Apply the same client IP resolution to:
  - `Auth`
  - `AuthAssert`
  - first-time setup in `LoginFunc`
- Keep default behavior safe: no trusted proxies configured means forwarded headers are ignored.
- Add docs/review notes and README examples for YAML-only `TrustedProxies` configuration.

# Motivation

`r.RemoteAddr` only represents the immediate TCP peer. When ddns-go runs behind a local or LAN reverse proxy, WAN clients may appear as the proxy’s loopback/private IP, causing `NotAllowWanAccess` checks to incorrectly allow access.

`r.RemoteAddr` 只代表直接连接 ddns-go 的 TCP peer。反向代理部署时，公网用户可能显示为代理的 loopback/private IP，导致 `NotAllowWanAccess` 判断错误放行。

This PR addresses the feedback from Copilot, but avoids blindly trusting `X-Real-IP` from any private peer. Instead, forwarded headers are trusted only from explicitly configured proxy addresses.

此次 PR 处理了 Copilot 反馈中提到的反代场景，但不会简单信任任意内网来源的 `X-Real-IP`，而是要求用户显式配置可信代理地址，降低 header spoofing 风险。

# Additional Notes

Configuration is YAML-only in this PR. No Web UI or CLI flag is added.

配置入口本次仅支持 YAML，未新增 Web UI 字段或 CLI 参数。

Example:

```yaml
TrustedProxies:
  - 127.0.0.1
  - ::1
  - 192.168.1.10
  - 172.18.0.0/16
```
