### PR TITLE
feat: add http server timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@
   - `-cacheTimes` 间隔N次与服务商比对
   - `-c` 自定义配置文件路径
   - `-noweb` 不启动web服务
+  - `-httpReadTimeout` HTTP 服务读取超时时间(秒), 默认10
+  - `-httpWriteTimeout` HTTP 服务写入超时时间(秒), 默认30
+  - `-httpIdleTimeout` HTTP 服务空闲连接超时时间(秒), 默认60
   - `-skipVerify` 跳过证书验证
   - `-dns` 自定义 DNS 服务器
   - `-resetPassword` 重置密码
@@ -86,10 +89,12 @@
   docker run -d --name ddns-go --restart=always --net=host -v /opt/ddns-go:/root ghcr.io/jeessy2/ddns-go
   ```
 
-- [可选] 支持启动带参数 `-l`监听地址 `-f`间隔时间(秒)
+- [可选] 支持启动带参数 `-l`监听地址 `-f`间隔时间(秒), 以及 HTTP 服务超时时间
 
   ```bash
-  docker run -d --name ddns-go --restart=always --net=host -v /opt/ddns-go:/root jeessy/ddns-go -l :9877 -f 600
+  docker run -d --name ddns-go --restart=always --net=host -v /opt/ddns-go:/root jeessy/ddns-go \
+    -l :9877 -f 600 \
+    -httpReadTimeout 10 -httpWriteTimeout 30 -httpIdleTimeout 60
   ```
 
 - [可选] 不使用docker host模式

--- a/README_EN.md
+++ b/README_EN.md
@@ -50,6 +50,9 @@ Automatically obtain your public IPv4 or IPv6 address and resolve it to the corr
   - `-cacheTimes` interval N times compared with service providers
   - `-c` custom configuration file path
   - `-noweb` does not start web service
+  - `-httpReadTimeout` HTTP server read timeout(seconds), default 10
+  - `-httpWriteTimeout` HTTP server write timeout(seconds), default 30
+  - `-httpIdleTimeout` HTTP server idle connection timeout(seconds), default 60
   - `-skipVerify` skip certificate verification
   - `-dns` custom DNS server
   - `-resetPassword` reset password
@@ -83,10 +86,12 @@ Automatically obtain your public IPv4 or IPv6 address and resolve it to the corr
   docker run -d --name ddns-go --restart=always --net=host -v /opt/ddns-go:/root ghcr.io/jeessy2/ddns-go
   ```
 
-- [Optional] Support startup with parameters `-l`listen address `-f`Sync frequency(seconds)
+- [Optional] Support startup with parameters `-l`listen address, `-f` sync frequency(seconds), and HTTP server timeouts
 
   ```bash
-  docker run -d --name ddns-go --restart=always --net=host -v /opt/ddns-go:/root jeessy/ddns-go -l :9877 -f 600
+  docker run -d --name ddns-go --restart=always --net=host -v /opt/ddns-go:/root jeessy/ddns-go \
+    -l :9877 -f 600 \
+    -httpReadTimeout 10 -httpWriteTimeout 30 -httpIdleTimeout 60
   ```
 
 - [Optional] Without using docker host mode

--- a/main.go
+++ b/main.go
@@ -49,6 +49,11 @@ var configFilePath = flag.String("c", util.GetConfigFilePathDefault(), "Custom c
 // Web 服务
 var noWebService = flag.Bool("noweb", false, "No web service")
 
+// HTTP 服务超时(秒)
+var httpReadTimeout = flag.Int("httpReadTimeout", 10, "HTTP server read timeout(seconds)")
+var httpWriteTimeout = flag.Int("httpWriteTimeout", 30, "HTTP server write timeout(seconds)")
+var httpIdleTimeout = flag.Int("httpIdleTimeout", 60, "HTTP server idle timeout(seconds)")
+
 // 跳过验证证书
 var skipVerify = flag.Bool("skipVerify", false, "Skip certificate verification")
 
@@ -211,7 +216,16 @@ func runWebServer() error {
 		return errors.New(util.LogStr("监听端口发生异常, 请检查端口是否被占用! %s", err))
 	}
 
-	return http.Serve(l, nil)
+	return newHTTPServer(nil).Serve(l)
+}
+
+func newHTTPServer(handler http.Handler) *http.Server {
+	return &http.Server{
+		Handler:      handler,
+		ReadTimeout:  time.Duration(*httpReadTimeout) * time.Second,
+		WriteTimeout: time.Duration(*httpWriteTimeout) * time.Second,
+		IdleTimeout:  time.Duration(*httpIdleTimeout) * time.Second,
+	}
 }
 
 // 以守护/分离进程方式运行（Unix 使用 setsid，Windows 使用 DETACHED_PROCESS）
@@ -262,6 +276,15 @@ func (p *program) Stop(s service.Service) error {
 }
 
 func getService() service.Service {
+	prg := &program{}
+	s, err := service.New(prg, getServiceConfig())
+	if err != nil {
+		log.Fatalln(err)
+	}
+	return s
+}
+
+func getServiceConfig() *service.Config {
 	options := make(service.KeyValue)
 	var depends []string
 
@@ -279,10 +302,18 @@ func getService() service.Service {
 	}
 
 	svcConfig := &service.Config{
-		Name:         "ddns-go",
-		DisplayName:  "ddns-go",
-		Description:  "Simple and easy to use DDNS. Automatically update domain name resolution to public IP (Support Aliyun, Tencent Cloud, Dnspod, Cloudflare, Callback, Huawei Cloud, Baidu Cloud, Porkbun, GoDaddy...)",
-		Arguments:    []string{"-l", *listen, "-f", strconv.Itoa(*every), "-cacheTimes", strconv.Itoa(*ipCacheTimes), "-c", *configFilePath},
+		Name:        "ddns-go",
+		DisplayName: "ddns-go",
+		Description: "Simple and easy to use DDNS. Automatically update domain name resolution to public IP (Support Aliyun, Tencent Cloud, Dnspod, Cloudflare, Callback, Huawei Cloud, Baidu Cloud, Porkbun, GoDaddy...)",
+		Arguments: []string{
+			"-l", *listen,
+			"-f", strconv.Itoa(*every),
+			"-cacheTimes", strconv.Itoa(*ipCacheTimes),
+			"-c", *configFilePath,
+			"-httpReadTimeout", strconv.Itoa(*httpReadTimeout),
+			"-httpWriteTimeout", strconv.Itoa(*httpWriteTimeout),
+			"-httpIdleTimeout", strconv.Itoa(*httpIdleTimeout),
+		},
 		Dependencies: depends,
 		Option:       options,
 	}
@@ -299,12 +330,7 @@ func getService() service.Service {
 		svcConfig.Arguments = append(svcConfig.Arguments, "-dns", *customDNS)
 	}
 
-	prg := &program{}
-	s, err := service.New(prg, svcConfig)
-	if err != nil {
-		log.Fatalln(err)
-	}
-	return s
+	return svcConfig
 }
 
 // 卸载服务


### PR DESCRIPTION

# What does this PR do?
为 ddns-go Web 服务新增可配置的 HTTP server timeout 设置。

## New CLI flags：

- `-httpReadTimeout`: HTTP server read timeout, default `10s` HTTP 服务读取超时时间，默认 `10s`
- `-httpWriteTimeout`: HTTP server write timeout, default `30s` HTTP 服务写入超时时间，默认 `30s`
- `-httpIdleTimeout`: HTTP server idle connection timeout, default `60s` HTTP 服务空闲连接超时时间，默认 `60s`

## Changes：

- Replace `http.Serve(l, nil)` with a configured `http.Server`
- Add default values for `ReadTimeout`, `WriteTimeout`, and `IdleTimeout`
- Allow users to override timeout values through CLI flags 支持用户通过 CLI 参数覆盖默认超时时间
- Pass the timeout flags into service install arguments
- Update README and README_EN with CLI and Docker usage examples 更新 README 相关

# Motivation
当前 Web 服务使用 `http.Serve(l, nil)`，没有配置 server timeout，存在 Slowloris 类风险。

# Additional Notes
none.