### PR TITLE
feat(callback): support custom request headers

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -64,6 +64,10 @@ type DNS struct {
 	Secret string
 	// ExtParam 扩展参数，用于某些DNS提供商的特殊需求（如Vercel的teamId）
 	ExtParam string
+	// Headers 自定义请求头，每行一个，如：Authorization: Bearer xxx。
+	// 为空时使用默认请求头。仅 callback 使用。
+	// 注：加 omitempty 是避免非 callback 的 DNS 配置保存时多出一个空 Headers 行。
+	Headers string `yaml:",omitempty"`
 }
 
 type Config struct {

--- a/dns/callback.go
+++ b/dns/callback.go
@@ -98,6 +98,11 @@ func (cb *Callback) addUpdateDomainRecords(recordType string) {
 			domain.UpdateStatus = config.UpdatedFailed
 			return
 		}
+		// 添加自定义请求头（支持与 URL/RequestBody 相同的变量替换），为空则仅保留默认请求头
+		headers := extractCallbackHeaders(cb.replacePara(cb.DNS.Headers, ipAddr, domain, recordType, cb.TTL))
+		for key, value := range headers {
+			req.Header.Add(key, value)
+		}
 		req.Header.Add("content-type", contentType)
 
 		resp, err := cb.httpClient.Do(req)
@@ -110,6 +115,27 @@ func (cb *Callback) addUpdateDomainRecords(recordType string) {
 			domain.UpdateStatus = config.UpdatedFailed
 		}
 	}
+}
+
+// extractCallbackHeaders 将"每行 Header: value"格式的字符串转换为 map。
+// 与 webhook 的 extractHeaders 实现隔离，避免影响 webhook 的日志语义。
+func extractCallbackHeaders(s string) map[string]string {
+	lines := util.SplitLines(s)
+	headers := make(map[string]string, len(lines))
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		parts := strings.SplitN(line, ":", 2)
+		if len(parts) != 2 {
+			util.Log("Callback Header格式不正确: %s", line)
+			continue
+		}
+		k, v := strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1])
+		headers[k] = v
+	}
+	return headers
 }
 
 // replacePara 替换参数

--- a/static/constant.js
+++ b/static/constant.js
@@ -78,6 +78,11 @@ const DNS_PROVIDERS = {
     helpHtml: {
       "en": "<a target='_blank' href='https://github.com/jeessy2/ddns-go/blob/master/README_EN.md#callback'>Callback</a> Support variables #{ip}, #{domain}, #{recordType}, #{ttl}",
       "zh-cn": "<a target='_blank' href='https://github.com/jeessy2/ddns-go#callback'>自定义回调</a> 支持的变量 #{ip}, #{domain}, #{recordType}, #{ttl}",
+    },
+    headersLabel: "Headers",
+    headersHelpHtml: {
+      "en": "One header per line, such as: Authorization: Bearer API_KEY. If empty, the default request header is used. Support variables #{ip}, #{domain}, #{recordType}, #{ttl}",
+      "zh-cn": "一行一个 Header, 如: Authorization: Bearer API_KEY。为空则使用默认请求头。支持变量 #{ip}, #{domain}, #{recordType}, #{ttl}"
     }
   },
   baiducloud: {

--- a/static/i18n.js
+++ b/static/i18n.js
@@ -254,6 +254,10 @@ const I18N_MAP = {
     'en': 'Optional. If you are using a Vercel Team account, please fill in the Team ID',
     'zh-cn': '可选项，如果您使用的是 Vercel 团队账户，请填写团队 ID'
   },
+  "callbackHeadersHelp": {
+    'en': 'One header per line, such as: Authorization: Bearer API_KEY. If empty, the default request header is used. Support variables #{ip}, #{domain}, #{recordType}, #{ttl}',
+    'zh-cn': '一行一个 Header, 如: Authorization: Bearer API_KEY。为空则使用默认请求头。支持变量 #{ip}, #{domain}, #{recordType}, #{ttl}'
+  },
 };
 
 const getCurrentLang = () => {

--- a/util/messages.go
+++ b/util/messages.go
@@ -54,6 +54,7 @@ func init() {
 	message.SetString(language.English, "Callback的URL不正确", "Callback URL is incorrect")
 	message.SetString(language.English, "Callback调用成功, 域名: %s, IP: %s, 返回数据: %s", "Successfully called Callback! Domain: %s, IP: %s, Response body: %s")
 	message.SetString(language.English, "Callback调用失败, 异常信息: %s", "Failed to call Callback! Exception: %s")
+	message.SetString(language.English, "Callback Header格式不正确: %s", "Callback header is invalid: %s")
 
 	// save
 	message.SetString(language.English, "必须输入用户名/密码", "Username/Password is required")

--- a/web/save.go
+++ b/web/save.go
@@ -85,6 +85,7 @@ func checkAndSave(request *http.Request) string {
 		dnsConf.DNS.ID = strings.TrimSpace(v.DnsID)
 		dnsConf.DNS.Secret = strings.TrimSpace(v.DnsSecret)
 		dnsConf.DNS.ExtParam = strings.TrimSpace(v.DnsExtParam)
+		dnsConf.DNS.Headers = strings.TrimSpace(v.DnsHeaders)
 
 		if v.Ipv4Domains == "" && v.Ipv6Domains == "" {
 			util.Log("第 %s 个配置未填写域名", util.Ordinal(k+1, conf.Lang))

--- a/web/writing.go
+++ b/web/writing.go
@@ -24,6 +24,7 @@ type dnsConf4JS struct {
 	DnsID            string
 	DnsSecret        string
 	DnsExtParam      string
+	DnsHeaders       string
 	TTL              string
 	Ipv4Enable       bool
 	Ipv4GetType      string
@@ -109,6 +110,7 @@ func getDnsConfStr(dnsConf []config.DnsConfig) string {
 			DnsID:            idHide,
 			DnsSecret:        secretHide,
 			DnsExtParam:      conf.DNS.ExtParam,
+			DnsHeaders:       conf.DNS.Headers,
 			TTL:              conf.TTL,
 			Ipv4Enable:       conf.Ipv4.Enable,
 			Ipv4GetType:      conf.Ipv4.GetType,

--- a/web/writing.html
+++ b/web/writing.html
@@ -110,6 +110,19 @@
                 </div>
               </div>
 
+              <div class="form-group row" id="DnsHeadersRow" style="display: none;">
+                <label for="DnsHeaders" id="dnsHeadersLabel" class="col-sm-2 col-form-label">Headers</label>
+                <div class="col-sm-10">
+                  <textarea class="form-control form" id="DnsHeaders" name="DnsHeaders" rows="2"
+                    aria-describedby="DnsHeadersHelp"></textarea>
+                  <small class="form-text text-muted">
+                    <span id="dnsHeadersHelp" data-i18n-html="callbackHeadersHelp">
+                      一行一个 Header, 如: Authorization: Bearer API_KEY。为空则使用默认请求头。支持变量 #{ip}, #{domain}, #{recordType}, #{ttl}
+                    </span>
+                  </small>
+                </div>
+              </div>
+
               <div class="form-group row">
                 <label class="col-sm-2 col-form-label">TTL</label>
                 <div class="col-sm-10">
@@ -401,6 +414,7 @@
     DnsName: "alidns",
     DnsSecret: "",
     DnsExtParam: "",
+    DnsHeaders: "",
     HttpInterface: "",
     Ipv4Cmd: "",
     Ipv4Domains: "",
@@ -454,6 +468,9 @@
       const $dnsExtParamRow = document.getElementById("DnsExtParamRow");
       const $dnsExtParamLabel = document.getElementById("dnsExtParamLabel");
       const $dnsExtParamHelp = document.getElementById("dnsExtParamHelp");
+      const $dnsHeadersRow = document.getElementById("DnsHeadersRow");
+      const $dnsHeadersLabel = document.getElementById("dnsHeadersLabel");
+      const $dnsHeadersHelp = document.getElementById("dnsHeadersHelp");
       // idLabel 为空时隐藏 DnsID
       if (dnsInfo.idLabel) {
         $dnsID.style.display = "block";
@@ -467,6 +484,14 @@
         $dnsExtParamHelp.innerHTML = i18n(dnsInfo.extParamHelpHtml);
       } else {
         $dnsExtParamRow.style.display = "none";
+      }
+      // 根据DNS提供商显示自定义请求头（仅 callback）
+      if (dnsInfo.headersLabel) {
+        $dnsHeadersRow.style.display = "";
+        $dnsHeadersLabel.innerHTML = dnsInfo.headersLabel;
+        $dnsHeadersHelp.innerHTML = i18n(dnsInfo.headersHelpHtml);
+      } else {
+        $dnsHeadersRow.style.display = "none";
       }
       document.getElementById("dnsIdLabel").innerHTML = dnsInfo.idLabel;
       document.getElementById("dnsSecretLabel").innerHTML = dnsInfo.secretLabel;
@@ -572,6 +597,9 @@
     const $dnsExtParamRow = document.getElementById("DnsExtParamRow");
     const $dnsExtParamLabel = document.getElementById("dnsExtParamLabel");
     const $dnsExtParamHelp = document.getElementById("dnsExtParamHelp");
+    const $dnsHeadersRow = document.getElementById("DnsHeadersRow");
+    const $dnsHeadersLabel = document.getElementById("dnsHeadersLabel");
+    const $dnsHeadersHelp = document.getElementById("dnsHeadersHelp");
     const dnsInfo = DNS_PROVIDERS[conf.DnsName];
     if (dnsInfo && dnsInfo.extParamLabel) {
       $dnsExtParamRow.style.display = "";
@@ -579,6 +607,14 @@
       $dnsExtParamHelp.innerHTML = i18n(dnsInfo.extParamHelpHtml);
     } else {
       $dnsExtParamRow.style.display = "none";
+    }
+    // 根据 DNS 提供商显示或隐藏自定义请求头输入框（仅 callback）
+    if (dnsInfo && dnsInfo.headersLabel) {
+      $dnsHeadersRow.style.display = "";
+      $dnsHeadersLabel.innerHTML = dnsInfo.headersLabel;
+      $dnsHeadersHelp.innerHTML = i18n(dnsInfo.headersHelpHtml);
+    } else {
+      $dnsHeadersRow.style.display = "none";
     }
   }
 


### PR DESCRIPTION
## Summary

为 Callback 新增自定义请求头功能。在配置页面新增 Headers 输入框，用户可填写自定义 HTTP 请求头（每行一个，如 `Authorization: Bearer xxx`）。**留空则保持原有默认请求头（仅 content-type），与原行为一致。**

## Changes

- `config/config.go`：DNS 结构体新增 `Headers` 字段（带 `yaml:",omitempty"`，避免非 callback 的 DNS 配置保存时多出空行）
- `dns/callback.go`：请求头注入 + 本地 `extractCallbackHeaders` 解析函数
- `util/messages.go`：新增 Header 格式错误日志的 i18n 翻译
- `web/writing.go` / `web/save.go`：Headers 字段的保存与回显
- `web/writing.html`：新增 Headers 输入框 UI（仅 callback 显示）
- `static/constant.js` / `static/i18n.js`：中英双语帮助文本

## Features

- 留空时保持默认请求头行为
- 支持多行请求头（每行一个 `Header: value`）
- 支持变量替换（`#{ip}` `#{domain}` `#{recordType}` `#{ttl}`），与 URL/RequestBody 一致
- `yaml:",omitempty"` 非 callback 的 DNS 配置文件格式不变
- Header 解析逻辑独立实现，不影响webhook 代码
- 包含中英双语 i18n 支持
- 所有改动均为新增（+79 行，0 删除）

## Test plan

- [x] `go build ./...` 通过
- [x] `go vet ./...` 通过
- [x] `go test ./...` 全部通过
- [x] Linux amd64/arm64 交叉编译通过
- [x] 不填 Headers：服务器仅收到默认请求头（content-type 等）
- [x] 填 Headers（`Authorization: Bearer fake_api_key`）：服务器正确收到自定义请求头，且默认 content-type 保留 
- [x] 多行 Headers（`Authorization: Bearer xxx` + `D: 2`）：两个请求头都正确送达 
- [x] 对比 master 原版：不填 Headers 时行为完全一致 