### PR TITLE
feat(web/auth): trust reverse-proxy forward-auth header

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,19 @@
   docker restart ddns-go
   ```
 
+## 反向代理认证 (forward-auth)
+
+当 ddns-go 部署在支持 forward-auth 的反向代理(如 Authentik、Authelia、Traefik)之后时, 可通过环境变量 `DDNS_GO_TRUSTED_AUTH_HEADER` 指定一个由代理注入的认证请求头, ddns-go 会信任该请求头并跳过自身登录, 避免二次登录。
+
+- 该变量为空或未设置时(默认), 行为完全不变。
+- 仅当请求来自私有网络(即经由内部反向代理)且该请求头存在时才生效, 公网客户端无法伪造此头绕过登录。
+
+```bash
+docker run -d --name ddns-go --restart=always --net=host \
+  -e DDNS_GO_TRUSTED_AUTH_HEADER=X-Authentik-Username \
+  -v /opt/ddns-go:/root jeessy/ddns-go
+```
+
 ## 使用IPv6
 
 - 前提：你的电脑或终端能正常获取IPv6，并能正常访问IPv6

--- a/README_EN.md
+++ b/README_EN.md
@@ -102,6 +102,19 @@ Automatically obtain your public IPv4 or IPv6 address and resolve it to the corr
   docker restart ddns-go
   ```
 
+## Reverse proxy authentication (forward-auth)
+
+When ddns-go runs behind a reverse proxy that performs forward-auth (e.g. Authentik, Authelia, Traefik), set the environment variable `DDNS_GO_TRUSTED_AUTH_HEADER` to the name of the auth header injected by the proxy. ddns-go then trusts that header and skips its own login, avoiding a double login.
+
+- When empty or unset (the default), behavior is unchanged.
+- It only takes effect when the request comes from a private network (i.e. via the internal reverse proxy) and the header is present, so public clients cannot spoof the header to bypass login.
+
+```bash
+docker run -d --name ddns-go --restart=always --net=host \
+  -e DDNS_GO_TRUSTED_AUTH_HEADER=X-Authentik-Username \
+  -v /opt/ddns-go:/root jeessy/ddns-go
+```
+
 ## Webhook
 
 - Support webhook, when the domain name is updated successfully or not, the URL filled in will be called back

--- a/web/auth.go
+++ b/web/auth.go
@@ -2,11 +2,20 @@ package web
 
 import (
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/jeessy2/ddns-go/v6/config"
 	"github.com/jeessy2/ddns-go/v6/util"
 )
+
+// TrustedAuthHeaderEnv, when set, names a request header injected by a trusted
+// reverse proxy performing forward-auth (e.g. Authentik, Authelia, Traefik).
+// If that header is present on a request coming from a private network, the
+// login check is bypassed so the proxy's authentication is trusted. Empty or
+// unset (the default) keeps the original behavior unchanged. The private-network
+// guard prevents public clients from spoofing the header.
+const TrustedAuthHeaderEnv = "DDNS_GO_TRUSTED_AUTH_HEADER"
 
 // ViewFunc func
 type ViewFunc func(http.ResponseWriter, *http.Request)
@@ -14,6 +23,11 @@ type ViewFunc func(http.ResponseWriter, *http.Request)
 // Auth 验证Token是否已经通过
 func Auth(f ViewFunc) ViewFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		// 信任反向代理注入的认证头(forward-auth), 仅对来自私网的请求生效, 防止公网伪造
+		if h := os.Getenv(TrustedAuthHeaderEnv); h != "" && r.Header.Get(h) != "" && util.IsPrivateNetwork(r.RemoteAddr) {
+			f(w, r)
+			return
+		}
 		cookieInWeb, err := r.Cookie(cookieName)
 		if err != nil {
 			http.Redirect(w, r, "./login", http.StatusTemporaryRedirect)


### PR DESCRIPTION
# What does this PR do?

Adds an opt-in `DDNS_GO_TRUSTED_AUTH_HEADER` environment variable. When it is set to the name of a request header, and that header is present on a request coming from a private network, ddns-go trusts the reverse proxy's authentication and skips its own login page. Documented in both README.md and README_EN.md.

新增一个可选的环境变量 `DDNS_GO_TRUSTED_AUTH_HEADER`。当它被设置为某个请求头的名称,且该请求头出现在来自私有网络的请求中时，ddns-go 会信任反向代理的认证结果、跳过自身的登录页。已在 README.md 和 README_EN.md 中补充文档。

# Motivation

When ddns-go runs behind a reverse proxy that already handles authentication via forward-auth (Authentik, Authelia, Traefik, ...), you currently have to log in twice: once at the SSO gateway and again at ddns-go's own login page. There is no way to disable the built-in login or to trust an upstream identity header. This lets the SSO gateway be the single point of login.

当 ddns-go 部署在已经通过 forward-auth 处理认证的反向代理（Authentik、Authelia、Traefik 等）之后时，目前需要登录两次：先在 SSO 网关登录，再在 ddns-go 自己的登录页登录。ddns-go 既无法关闭自带登录,也无法信任上游注入的身份头。本 PR 让 SSO 网关成为唯一的登录入口。

# Additional Notes

- Default off — when the variable is empty or unset, behavior is unchanged.
- Only honored for requests from a private network (reusing the existing `util.IsPrivateNetwork(r.RemoteAddr)` helper), so a public client cannot spoof the header to bypass login.

- 默认关闭，变量为空或未设置时行为完全不变。
- 仅对来自私有网络的请求生效（复用现有的 `util.IsPrivateNetwork(r.RemoteAddr)`），公网客户端无法伪造该请求头绕过登录。
