### PR TITLE
feat(dns): 新增 deSEC DNS 服务商支持

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 ## 特性
 
 - 支持Mac、Windows、Linux系统，支持ARM、x86、RISC-V架构
-- 支持的域名服务商 `阿里云` `阿里云 ESA` `腾讯云` `Dnspod` `Cloudflare` `华为云` `Callback` `百度云` `Porkbun` `GoDaddy` `Namecheap` `NameSilo` `Dynadot` `DNSLA` `时代互联` `Eranet` `Tnethk` `Gcore` `EdgeOne` `IBM NS1 Connect` `雨云`
+- 支持的域名服务商 `阿里云` `阿里云 ESA` `腾讯云` `Dnspod` `Cloudflare` `华为云` `Callback` `百度云` `Porkbun` `GoDaddy` `Namecheap` `NameSilo` `Dynadot` `DNSLA` `时代互联` `Eranet` `Tnethk` `Gcore` `EdgeOne` `IBM NS1 Connect` `雨云` `deSEC`
 - 支持接口/网卡/[命令](https://github.com/jeessy2/ddns-go/wiki/通过命令获取IP参考)获取IP
 - 支持以服务的方式运行
 - 默认间隔5分钟同步一次

--- a/README_EN.md
+++ b/README_EN.md
@@ -17,7 +17,7 @@ Automatically obtain your public IPv4 or IPv6 address and resolve it to the corr
 ## Features
 
 - Support Mac, Windows, Linux system, support ARM, x86, RISC-V architecture
-- Support domain service providers `Aliyun` `Aliyun ESA` `Tencent` `Dnspod` `Cloudflare` `Huawei` `Callback` `Baidu` `Porkbun` `GoDaddy` `Namecheap` `NameSilo` `Dynadot` `DNSLA` `Nowcn` `Eranet` `Gcore` `EdgeOne` `IBM NS1 Connect` `Rainyun`
+- Support domain service providers `Aliyun` `Aliyun ESA` `Tencent` `Dnspod` `Cloudflare` `Huawei` `Callback` `Baidu` `Porkbun` `GoDaddy` `Namecheap` `NameSilo` `Dynadot` `DNSLA` `Nowcn` `Eranet` `Gcore` `EdgeOne` `IBM NS1 Connect` `Rainyun` `deSEC`
 - Support interface / netcard / command to get IP
 - Support running as a service
 - Default interval is 5 minutes

--- a/dns/desec.go
+++ b/dns/desec.go
@@ -1,0 +1,198 @@
+package dns
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+
+	"github.com/jeessy2/ddns-go/v6/config"
+	"github.com/jeessy2/ddns-go/v6/util"
+)
+
+const desecEndpoint = "https://desec.io/api/v1"
+
+// deSEC TTL限制: 最小3600秒(域名默认最小TTL), 最大86400秒
+const (
+	desecMinTTL = 3600
+	desecMaxTTL = 86400
+)
+
+// DeSEC deSEC DNS实现
+type DeSEC struct {
+	DNS        config.DNS
+	Domains    config.Domains
+	TTL        int
+	httpClient *http.Client
+	lastStatus int
+}
+
+// DeSECRRSet RRSet记录实体
+type DeSECRRSet struct {
+	SubDomain string   `json:"subname"`
+	Type      string   `json:"type"`
+	Records   []string `json:"records"`
+	TTL       int      `json:"ttl"`
+}
+
+// Init 初始化
+func (desec *DeSEC) Init(dnsConf *config.DnsConfig, ipv4cache *util.IpCache, ipv6cache *util.IpCache) {
+	desec.Domains.Ipv4Cache = ipv4cache
+	desec.Domains.Ipv6Cache = ipv6cache
+	desec.DNS = dnsConf.DNS
+	desec.Domains.GetNewIp(dnsConf)
+	desec.TTL = desecMinTTL
+	if ttl, err := strconv.Atoi(dnsConf.TTL); err == nil {
+		if ttl > desecMinTTL {
+			desec.TTL = ttl
+		}
+		if ttl > desecMaxTTL {
+			desec.TTL = desecMaxTTL
+		}
+	}
+	desec.httpClient = dnsConf.GetHTTPClient()
+}
+
+// AddUpdateDomainRecords 添加或更新IPv4/IPv6记录
+func (desec *DeSEC) AddUpdateDomainRecords() config.Domains {
+	desec.addUpdateDomainRecords("A")
+	desec.addUpdateDomainRecords("AAAA")
+	return desec.Domains
+}
+
+func (desec *DeSEC) addUpdateDomainRecords(recordType string) {
+	ipAddr, domains := desec.Domains.GetNewIpResult(recordType)
+
+	if ipAddr == "" {
+		return
+	}
+
+	for _, domain := range domains {
+		// 按subname+type过滤查询，域名或记录不存在返回空数组，域名不存在返回404
+		rrsets, status, err := desec.getRRSets(domain.DomainName, domain.SubDomain, recordType)
+		if err != nil {
+			if status == http.StatusNotFound {
+				util.Log("在DNS服务商中未找到根域名: %s", domain.DomainName)
+			} else {
+				util.Log("查询域名信息发生异常! %s", err)
+			}
+			domain.UpdateStatus = config.UpdatedFailed
+			continue
+		}
+
+		if len(rrsets) > 0 && len(rrsets[0].Records) > 0 && rrsets[0].Records[0] == ipAddr {
+			// ip与dns服务器一致，不执行更新
+			util.Log("你的IP %s 没有变化, 域名 %s", ipAddr, domain)
+			continue
+		}
+
+		if len(rrsets) > 0 {
+			// 更新记录
+			desec.modify(domain, recordType, ipAddr)
+		} else {
+			// 创建记录
+			desec.create(domain, recordType, ipAddr)
+		}
+	}
+}
+
+// getRRSets 按subname和type过滤查询rrsets
+func (desec *DeSEC) getRRSets(zone string, subDomain string, recordType string) (rrsets []DeSECRRSet, status int, err error) {
+	params := url.Values{}
+	params.Set("subname", subDomain)
+	params.Set("type", recordType)
+
+	_, err = desec.request(
+		"GET",
+		fmt.Sprintf("%s/domains/%s/rrsets/?%s", desecEndpoint, zone, params.Encode()),
+		nil,
+		&rrsets,
+	)
+
+	return rrsets, desec.lastStatus, err
+}
+
+// create 创建新的解析
+func (desec *DeSEC) create(domain *config.Domain, recordType string, ipAddr string) {
+	rrset := DeSECRRSet{
+		SubDomain: domain.SubDomain,
+		Type:      recordType,
+		Records:   []string{ipAddr},
+		TTL:       desec.TTL,
+	}
+
+	var result DeSECRRSet
+	_, err := desec.request(
+		"POST",
+		fmt.Sprintf("%s/domains/%s/rrsets/", desecEndpoint, domain.DomainName),
+		rrset,
+		&result,
+	)
+
+	if err != nil {
+		util.Log("新增域名解析 %s 失败! 异常信息: %s", domain, err)
+		domain.UpdateStatus = config.UpdatedFailed
+	} else {
+		util.Log("新增域名解析 %s 成功! IP: %s", domain, ipAddr)
+		domain.UpdateStatus = config.UpdatedSuccess
+	}
+}
+
+// modify 更新解析
+func (desec *DeSEC) modify(domain *config.Domain, recordType string, ipAddr string) {
+	rrset := DeSECRRSet{
+		SubDomain: domain.SubDomain,
+		Type:      recordType,
+		Records:   []string{ipAddr},
+		TTL:       desec.TTL,
+	}
+
+	// 批量PATCH接口，可更新单个rrset，主域名的subname为空字符串
+	var result []DeSECRRSet
+	_, err := desec.request(
+		"PATCH",
+		fmt.Sprintf("%s/domains/%s/rrsets/", desecEndpoint, domain.DomainName),
+		[]DeSECRRSet{rrset},
+		&result,
+	)
+
+	if err != nil {
+		util.Log("更新域名解析 %s 失败! 异常信息: %s", domain, err)
+		domain.UpdateStatus = config.UpdatedFailed
+	} else {
+		util.Log("更新域名解析 %s 成功! IP: %s", domain, ipAddr)
+		domain.UpdateStatus = config.UpdatedSuccess
+	}
+}
+
+// request 统一请求接口，返回响应状态码
+func (desec *DeSEC) request(method string, url string, data interface{}, result interface{}) (status int, err error) {
+	jsonStr := make([]byte, 0)
+	if data != nil {
+		jsonStr, _ = json.Marshal(data)
+	}
+
+	req, err := http.NewRequest(
+		method,
+		url,
+		bytes.NewBuffer(jsonStr),
+	)
+
+	if err != nil {
+		return
+	}
+
+	req.Header.Set("Authorization", "Token "+desec.DNS.Secret)
+	req.Header.Set("Content-Type", "application/json")
+
+	client := desec.httpClient
+	resp, err := client.Do(req)
+	if resp != nil {
+		status = resp.StatusCode
+		desec.lastStatus = resp.StatusCode
+	}
+	err = util.GetHTTPResponse(resp, err, result)
+	return
+}

--- a/dns/desec_test.go
+++ b/dns/desec_test.go
@@ -1,0 +1,215 @@
+package dns
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/jeessy2/ddns-go/v6/config"
+	"github.com/jeessy2/ddns-go/v6/util"
+)
+
+func TestDesecAddUpdateDomainRecords(t *testing.T) {
+	tests := []struct {
+		name         string
+		subDomain    string
+		recordType   string
+		recordIP     string
+		ipAddr       string
+		wantRequests int // 预期请求数(含查询)
+		wantMethod   string
+	}{
+		{
+			name:         "ip unchanged, no update request",
+			subDomain:    "www",
+			recordType:   "A",
+			recordIP:     "192.0.2.1",
+			ipAddr:       "192.0.2.1",
+			wantRequests: 1,
+		},
+		{
+			name:         "ip changed, patch existing record",
+			subDomain:    "www",
+			recordType:   "A",
+			recordIP:     "192.0.2.1",
+			ipAddr:       "192.0.2.2",
+			wantRequests: 2,
+			wantMethod:   "PATCH",
+		},
+		{
+			name:         "record not found, create new record",
+			subDomain:    "www",
+			recordType:   "A",
+			recordIP:     "",
+			ipAddr:       "192.0.2.2",
+			wantRequests: 2,
+			wantMethod:   "POST",
+		},
+		{
+			name:         "apex domain uses empty subname",
+			subDomain:    "",
+			recordType:   "AAAA",
+			recordIP:     "2001:db8::1",
+			ipAddr:       "2001:db8::2",
+			wantRequests: 2,
+			wantMethod:   "PATCH",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			requestCount := 0
+			var lastMethod string
+			var lastBody []DeSECRRSet
+			client := &http.Client{
+				Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
+					requestCount++
+					if request.Method == "GET" {
+						// 校验过滤参数
+						if got := request.URL.Query().Get("subname"); got != tt.subDomain {
+							t.Errorf("subname filter = %q, want %q", got, tt.subDomain)
+						}
+						if got := request.URL.Query().Get("type"); got != tt.recordType {
+							t.Errorf("type filter = %q, want %q", got, tt.recordType)
+						}
+						records := "[]"
+						if tt.recordIP != "" {
+							records = `[{"subdomain":"` + tt.subDomain + `","type":"` + tt.recordType + `","records":["` + tt.recordIP + `"],"ttl":3600}]`
+						}
+						return &http.Response{
+							StatusCode: http.StatusOK,
+							Body:       io.NopCloser(strings.NewReader(records)),
+							Header:     make(http.Header),
+						}, nil
+					}
+					lastMethod = request.Method
+					// POST为单个rrset对象，PATCH为rrset数组，统一包裹为数组处理
+					body, readErr := io.ReadAll(request.Body)
+					if readErr != nil {
+						t.Fatalf("read request body: %v", readErr)
+					}
+					if lastMethod == "POST" {
+						var single DeSECRRSet
+						if err := json.Unmarshal(body, &single); err != nil {
+							t.Fatalf("decode request body: %v", err)
+						}
+						lastBody = []DeSECRRSet{single}
+					} else if err := json.Unmarshal(body, &lastBody); err != nil {
+						t.Fatalf("decode request body: %v", err)
+					}
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Body:       io.NopCloser(strings.NewReader(`[]`)),
+						Header:     make(http.Header),
+					}, nil
+				}),
+			}
+
+			desec := DeSEC{TTL: 3600, httpClient: client}
+			domain := &config.Domain{
+				DomainName: "example.com",
+				SubDomain:  tt.subDomain,
+			}
+
+			ipv4Cache := &util.IpCache{}
+			ipv6Cache := &util.IpCache{}
+			desec.Domains.Ipv4Cache = ipv4Cache
+			desec.Domains.Ipv6Cache = ipv6Cache
+
+			if tt.recordType == "A" {
+				desec.Domains.Ipv4Addr = tt.ipAddr
+				desec.Domains.Ipv4Domains = []*config.Domain{domain}
+				// 使缓存检查通过
+				ipv4Cache.Times = 1
+			} else {
+				desec.Domains.Ipv6Addr = tt.ipAddr
+				desec.Domains.Ipv6Domains = []*config.Domain{domain}
+				ipv6Cache.Times = 1
+			}
+
+			desec.addUpdateDomainRecords(tt.recordType)
+
+			if requestCount != tt.wantRequests {
+				t.Fatalf("request count = %d, want %d", requestCount, tt.wantRequests)
+			}
+			if tt.wantRequests == 2 {
+				if lastMethod != tt.wantMethod {
+					t.Errorf("method = %s, want %s", lastMethod, tt.wantMethod)
+				}
+				if len(lastBody) == 0 {
+					t.Fatalf("request body is empty")
+				}
+				rrset := lastBody[0]
+				if rrset.SubDomain != tt.subDomain {
+					t.Errorf("subname = %q, want %q", rrset.SubDomain, tt.subDomain)
+				}
+				if rrset.Type != tt.recordType {
+					t.Errorf("type = %s, want %s", rrset.Type, tt.recordType)
+				}
+				if len(rrset.Records) != 1 || rrset.Records[0] != tt.ipAddr {
+					t.Errorf("records = %v, want [%s]", rrset.Records, tt.ipAddr)
+				}
+				if rrset.TTL != 3600 {
+					t.Errorf("ttl = %d, want 3600", rrset.TTL)
+				}
+			}
+		})
+	}
+}
+
+func TestDesecZoneNotFound(t *testing.T) {
+	client := &http.Client{
+		Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusNotFound,
+				Body:       io.NopCloser(strings.NewReader(`{"detail":"Not found."}`)),
+				Header:     make(http.Header),
+			}, nil
+		}),
+	}
+
+	desec := DeSEC{TTL: 3600, httpClient: client}
+	domain := &config.Domain{
+		DomainName: "nonexistent.com",
+		SubDomain:  "www",
+	}
+	desec.Domains.Ipv4Cache = &util.IpCache{}
+	desec.Domains.Ipv6Cache = &util.IpCache{}
+	desec.Domains.Ipv4Addr = "192.0.2.1"
+	desec.Domains.Ipv4Domains = []*config.Domain{domain}
+	desec.Domains.Ipv4Cache.Times = 1
+
+	desec.addUpdateDomainRecords("A")
+
+	if domain.UpdateStatus != config.UpdatedFailed {
+		t.Errorf("update status = %v, want UpdatedFailed", domain.UpdateStatus)
+	}
+}
+
+func TestDesecInitTTL(t *testing.T) {
+	tests := []struct {
+		name      string
+		ttl       string
+		wantValue int
+	}{
+		{name: "default ttl", ttl: "", wantValue: 3600},
+		{name: "custom ttl", ttl: "7200", wantValue: 7200},
+		{name: "below minimum clamped", ttl: "300", wantValue: 3600},
+		{name: "invalid ttl falls back", ttl: "abc", wantValue: 3600},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conf := config.DnsConfig{}
+			conf.DNS.Name = "desec"
+			conf.TTL = tt.ttl
+			desec := DeSEC{}
+			desec.Init(&conf, &util.IpCache{}, &util.IpCache{})
+			if desec.TTL != tt.wantValue {
+				t.Errorf("ttl = %d, want %d", desec.TTL, tt.wantValue)
+			}
+		})
+	}
+}

--- a/dns/index.go
+++ b/dns/index.go
@@ -32,6 +32,7 @@ var (
 		edgeoneEndPoint,
 		rainyunEndpoint,
 		CloudnsEndpoint,
+		desecEndpoint,
 	}
 
 	Ipcache = [][2]util.IpCache{}
@@ -117,6 +118,8 @@ func RunOnce() {
 			dnsSelected = &HiPMDnsMgr{}
 		case "cloudns":
 			dnsSelected = &ClouDNS{}
+		case "desec":
+			dnsSelected = &DeSEC{}
 		default:
 			dnsSelected = &Alidns{}
 		}

--- a/static/constant.js
+++ b/static/constant.js
@@ -329,6 +329,17 @@ const DNS_PROVIDERS = {
       "zh-cn": "<a target='_blank' href='https://www.cloudns.net/wiki/article/42/'>创建 API 用户</a>",
     }
   },
+  desec: {
+    name: {
+      "en": "deSEC",
+    },
+    idLabel: "",
+    secretLabel: "Token",
+    helpHtml: {
+      "en": "<a target='_blank' href='https://desec.io/tokens'>Create Token</a>",
+      "zh-cn": "<a target='_blank' href='https://desec.io/tokens'>创建令牌</a>",
+    }
+  },
 };
 
 const SVG_CODE = {


### PR DESCRIPTION
- 实现dns/desec.go，采用Token认证，支持IPv4/IPv6记录的查询、创建与更新
- 使用subname+type过滤查询rrsets，避免拉取全量列表（deSEC有分页与限流）
- PATCH批量接口更新记录，POST创建记录，主域名subname传空字符串
- TTL限制在3600-86400秒之间，非法或过小回落到3600
- 注册provider到index.go，前端constant.js添加deSEC配置，更新README
- 附带单元测试：IP未变不请求、IP变化PATCH、记录不存在POST、主域名、404、TTL边界

# What does this PR do?

# Motivation

# Additional Notes
